### PR TITLE
A03/A04: add packet builder candidate ranking step

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - `docs/call_xref_legacy.csv` — legacy byte-scan call reference for comparison.
 - `docs/function_map.csv` — preliminary reachable function map with XDATA/MOVC evidence.
 - `docs/basic_block_map.csv` — preliminary basic block map separating function entries from internal branch targets.
+- `docs/a03_a04_packet_builder_candidates.csv` — A03/A04 packet builder candidate ranking.
 - Предыдущий файл анализа/журнал: `PZU_ANALYSIS.md`
 
 ## Исходные образы

--- a/docs/a03_a04_packet_builder_analysis.md
+++ b/docs/a03_a04_packet_builder_analysis.md
@@ -1,0 +1,73 @@
+# A03/A04 packet builder candidate analysis
+
+Область этого шага ограничена **только веткой A03_A04** и только образами `A03_26.PZU` и `A04_28.PZU`.
+
+## Что считается packet-pipeline candidate XDATA
+
+В ранжировании `docs/a03_a04_packet_builder_candidates.csv` использованы следующие индикаторы:
+
+- `snapshot_hits`: `0x3110`, `0x3128`;
+- `queue_hits`: `0x329C`;
+- `selector_hits`: `0x329D`;
+- `object_table_hits`: `0x343D` и nearby-доступы около `0x343D` (окно ±`0x10`);
+- `packet_xdata_hits`: диапазон `0x5003..0x5010`;
+- дополнительные pipeline-адреса для заметок: `0x3298`, `0x32A2`.
+
+Scoring-признаки:
+
+- `+3` packet_xdata_hits;
+- `+3` queue_hits;
+- `+3` selector_hits;
+- `+2` snapshot_hits;
+- `+2` object_table_hits;
+- `+1`, если `xdata_write_count > 0`;
+- `+1`, если `xdata_read_count > 0`;
+- `+1`, если `incoming_lcalls > 0`;
+- `+1`, если `role_candidate` содержит `packet` / `service` / `dispatcher`.
+
+Confidence:
+
+- `probable`: `score >= 6`;
+- `hypothesis`: `score = 3..5`;
+- `unknown`: `score < 3`.
+
+## Top-10 функций по score
+
+| rank | file | function_addr | score | confidence | ключевые признаки |
+|---:|---|---|---:|---|---|
+| 1 | A04_28.PZU | 0x889F | 13 | probable | queue + selector + packet window |
+| 2 | A03_26.PZU | 0x8904 | 10 | probable | queue + selector + aux(0x3298/0x32A2) |
+| 3 | A04_28.PZU | 0x722E | 9 | probable | queue + packet window + aux |
+| 4 | A04_28.PZU | 0x714C | 7 | probable | packet window |
+| 5 | A03_26.PZU | 0x7259 | 7 | probable | queue |
+| 6 | A04_28.PZU | 0xA2E2 | 6 | probable | packet window |
+| 7 | A04_28.PZU | 0xB310 | 6 | probable | packet window |
+| 8 | A04_28.PZU | 0x6B57 | 6 | probable | packet window |
+| 9 | A04_28.PZU | 0x8E4C | 6 | probable | packet window |
+| 10 | A04_28.PZU | 0x8F4A | 6 | probable | packet window |
+
+## Почему это кандидаты
+
+- **[confidence: probable]** Верхние кандидаты получают score за комбинацию queue/selector и packet-window (`0x5003..0x5010`) плюс признаки «живости» функции (`incoming_lcalls`, XDATA read/write).
+- **[confidence: probable]** `0x889F` (A04) и `0x8904` (A03) выделяются как наиболее плотные по packet-pipeline индикаторам: есть совместные попадания в `0x329C`/`0x329D` и дополнительные вызовные/блочные признаки.
+- **[confidence: hypothesis]** Группа функций с score `6..7` может быть как packet-builder path, так и runtime writer/helper path; пока это ранжирование по косвенным признакам, не proof wire-format.
+
+## Что подтверждено vs что остаётся гипотезой
+
+Подтверждено на уровне текущего шага:
+
+- **[confidence: probable]** В A03/A04 есть функции с устойчивыми hit-ами по `0x329C`, `0x329D`, `0x5003..0x5010`.
+- **[confidence: probable]** На текущем датасете нет hit-ов по snapshot (`0x3110`, `0x3128`) и object-table (`0x343D ± 0x10`) в отобранных кандидатов (поля `snapshot_hits/object_table_hits` остаются `0`).
+
+Остаётся гипотезой:
+
+- **[confidence: hypothesis]** Разделение на «packet_builder» vs «runtime packet writer» внутри top-кандидатов без трасс исполнения.
+- **[confidence: hypothesis]** Семантика полей пакета и точная структура payload только по этим hit-ам.
+
+## Что ещё нужно для восстановления wire-format
+
+- **[confidence: probable]** Трассировка runtime-пути (эмуляция/логирование) для top-5 кандидатов с фиксацией последовательности записей в `0x5003..0x5010`.
+- **[confidence: probable]** Корреляция вызовов кандидатов с типами событий/команд, чтобы связать selector/queue с конкретными packet type.
+- **[confidence: hypothesis]** Дополнительные подтверждения по object-table/snapshot путям в соседних ветках или через расширенный xref, если эти адреса участвуют опосредованно.
+
+Важно: на этом шаге **не утверждается**, что формат пакета восстановлен; выполнено только ранжирование кандидатов.

--- a/docs/a03_a04_packet_builder_candidates.csv
+++ b/docs/a03_a04_packet_builder_candidates.csv
@@ -1,0 +1,213 @@
+file,function_addr,role_candidate,basic_block_count,internal_block_count,incoming_lcalls,call_count,xdata_read_count,xdata_write_count,movc_count,packet_xdata_hits,queue_hits,selector_hits,snapshot_hits,object_table_hits,score,confidence,notes
+A04_28.PZU,0x889F,dispatcher_or_router,13,12,1,14,15,2,0,2,8,4,0,0,13,probable,queue@0x329C; selector@0x329D; packet_window@0x5003-0x5010; call_xref_lcalls=1; bb_parent_hits=13
+A03_26.PZU,0x8904,dispatcher_or_router,13,12,1,14,15,2,0,0,1,1,0,0,10,probable,queue@0x329C; selector@0x329D; aux@0x3298/0x32A2; call_xref_lcalls=1; bb_parent_hits=13
+A04_28.PZU,0x722E,state_update_worker,3,2,1,1,61,22,6,7,1,0,0,0,9,probable,queue@0x329C; packet_window@0x5003-0x5010; aux@0x3298/0x32A2; call_xref_lcalls=1; bb_parent_hits=3
+A04_28.PZU,0x714C,state_reader_or_packet_builder,1,0,1,4,8,1,0,1,0,0,0,0,7,probable,packet_window@0x5003-0x5010; call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x7259,state_reader_or_packet_builder,1,0,1,3,8,1,0,0,1,0,0,0,7,probable,queue@0x329C; call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0xA2E2,state_reader_or_packet_builder,3,2,13,8,5,0,0,4,0,0,0,0,6,probable,packet_window@0x5003-0x5010; call_xref_lcalls=13; bb_parent_hits=3
+A04_28.PZU,0xB310,state_reader_or_packet_builder,1,0,1,32,13,0,0,4,0,0,0,0,6,probable,packet_window@0x5003-0x5010; call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x6B57,state_reader_or_packet_builder,20,19,2,3,5,0,1,3,0,0,0,0,6,probable,packet_window@0x5003-0x5010; call_xref_lcalls=2; bb_parent_hits=20
+A04_28.PZU,0x8E4C,state_reader_or_packet_builder,8,7,1,2,6,0,0,3,0,0,0,0,6,probable,packet_window@0x5003-0x5010; call_xref_lcalls=1; bb_parent_hits=8
+A04_28.PZU,0x8F4A,unknown,5,4,1,1,2,1,0,2,0,0,0,0,6,probable,packet_window@0x5003-0x5010; call_xref_lcalls=1; bb_parent_hits=5
+A04_28.PZU,0x950F,state_update_worker,2,1,1,1,31,6,0,2,0,0,0,0,6,probable,packet_window@0x5003-0x5010; call_xref_lcalls=1; bb_parent_hits=2
+A04_28.PZU,0xADFE,state_reader_or_packet_builder,3,2,1,3,6,0,0,2,0,0,0,0,6,probable,packet_window@0x5003-0x5010; call_xref_lcalls=1; bb_parent_hits=3
+A04_28.PZU,0x805D,state_update_worker,7,6,1,3,10,4,0,1,0,0,0,0,6,probable,packet_window@0x5003-0x5010; aux@0x3298/0x32A2; call_xref_lcalls=1; bb_parent_hits=7
+A04_28.PZU,0x89C9,unknown,1,0,1,1,1,1,0,1,0,0,0,0,6,probable,packet_window@0x5003-0x5010; call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x8AA6,state_update_worker,1,0,1,1,19,3,0,1,0,0,0,0,6,probable,packet_window@0x5003-0x5010; call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x8F72,state_reader_or_packet_builder,3,2,2,3,17,0,0,1,0,0,0,0,6,probable,packet_window@0x5003-0x5010; call_xref_lcalls=2; bb_parent_hits=3
+A04_28.PZU,0xA6D9,state_update_worker,1,0,1,16,26,4,0,1,0,0,0,0,6,probable,packet_window@0x5003-0x5010; call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x7339,state_update_worker,3,2,1,1,39,16,2,0,4,0,0,0,6,probable,queue@0x329C; aux@0x3298/0x32A2; call_xref_lcalls=1; bb_parent_hits=3
+A04_28.PZU,0x8808,dispatcher_or_router,7,6,1,5,8,0,0,0,4,0,0,0,6,probable,queue@0x329C; aux@0x3298/0x32A2; call_xref_lcalls=1; bb_parent_hits=7
+A03_26.PZU,0x7953,state_update_worker,4,3,1,4,22,6,4,0,3,0,0,0,6,probable,queue@0x329C; call_xref_lcalls=1; bb_parent_hits=4
+A03_26.PZU,0x8B0B,state_update_worker,1,0,1,1,19,3,0,0,1,0,0,0,6,probable,queue@0x329C; call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0xA900,state_reader_or_packet_builder,3,2,1,33,14,0,0,0,1,0,0,0,6,probable,queue@0x329C; call_xref_lcalls=1; bb_parent_hits=3
+A04_28.PZU,0x497A,state_update_worker,3,2,0,99,8,5,0,5,0,0,0,0,5,hypothesis,packet_window@0x5003-0x5010; bb_parent_hits=3
+A03_26.PZU,0x70B3,state_reader_or_packet_builder,3,2,1,0,11,1,0,0,0,0,0,0,4,hypothesis,call_xref_lcalls=1; bb_parent_hits=3
+A03_26.PZU,0x9F58,state_reader_or_packet_builder,3,2,1,31,3,1,0,0,0,0,0,0,4,hypothesis,call_xref_lcalls=1; bb_parent_hits=3
+A04_28.PZU,0x6F83,state_reader_or_packet_builder,3,2,2,0,11,1,0,0,0,0,0,0,4,hypothesis,call_xref_lcalls=2; bb_parent_hits=3
+A04_28.PZU,0xA269,state_reader_or_packet_builder,3,2,1,30,3,1,0,0,0,0,0,0,4,hypothesis,call_xref_lcalls=1; bb_parent_hits=3
+A03_26.PZU,0x6C7E,state_reader_or_packet_builder,20,19,2,3,5,0,1,0,0,0,0,0,3,hypothesis,call_xref_lcalls=2; bb_parent_hits=20
+A03_26.PZU,0x6D8D,state_reader_or_packet_builder,1,0,1,2,3,0,0,0,0,0,0,0,3,hypothesis,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x800B,unknown,5,4,1,21,4,2,1,0,0,0,0,0,3,hypothesis,call_xref_lcalls=1; bb_parent_hits=5
+A03_26.PZU,0x80C3,state_update_worker,9,8,1,0,5,3,0,0,0,0,0,0,3,hypothesis,call_xref_lcalls=1; bb_parent_hits=9
+A03_26.PZU,0x810E,state_update_worker,7,6,1,3,11,4,0,0,0,0,0,0,3,hypothesis,call_xref_lcalls=1; bb_parent_hits=7
+A03_26.PZU,0x86C5,state_update_worker,6,5,1,3,7,4,0,0,0,0,0,0,3,hypothesis,call_xref_lcalls=1; bb_parent_hits=6
+A03_26.PZU,0x8741,state_update_worker,1,0,1,12,16,4,0,0,0,0,0,0,3,hypothesis,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x886D,dispatcher_or_router,7,6,1,5,8,0,0,0,0,0,0,0,3,hypothesis,aux@0x3298/0x32A2; call_xref_lcalls=1; bb_parent_hits=7
+A03_26.PZU,0x8A2E,unknown,1,0,1,1,1,1,0,0,0,0,0,0,3,hypothesis,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x8EB1,state_reader_or_packet_builder,8,7,1,2,6,0,0,0,0,0,0,0,3,hypothesis,call_xref_lcalls=1; bb_parent_hits=8
+A03_26.PZU,0x8F0F,unknown,1,0,1,4,2,1,0,0,0,0,0,0,3,hypothesis,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x8FAF,unknown,5,4,1,1,2,1,0,0,0,0,0,0,3,hypothesis,call_xref_lcalls=1; bb_parent_hits=5
+A03_26.PZU,0x8FD7,state_reader_or_packet_builder,3,2,2,3,9,0,0,0,0,0,0,0,3,hypothesis,call_xref_lcalls=2; bb_parent_hits=3
+A03_26.PZU,0x9439,dispatcher_or_router,8,7,2,5,1,0,0,0,0,0,0,0,3,hypothesis,call_xref_lcalls=2; bb_parent_hits=8
+A03_26.PZU,0x9FD8,state_reader_or_packet_builder,3,2,13,8,4,0,0,0,0,0,0,0,3,hypothesis,call_xref_lcalls=13; bb_parent_hits=3
+A03_26.PZU,0xA2F5,state_update_worker,1,0,1,16,23,3,0,0,0,0,0,0,3,hypothesis,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x6C66,state_reader_or_packet_builder,1,0,1,2,3,0,0,0,0,0,0,0,3,hypothesis,aux@0x3298/0x32A2; call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x7F5B,unknown,5,4,1,20,4,2,1,0,0,0,0,0,3,hypothesis,aux@0x3298/0x32A2; call_xref_lcalls=1; bb_parent_hits=5
+A04_28.PZU,0x8012,state_update_worker,9,8,1,0,5,3,0,0,0,0,0,0,3,hypothesis,aux@0x3298/0x32A2; call_xref_lcalls=1; bb_parent_hits=9
+A04_28.PZU,0x866A,state_update_worker,6,5,1,3,7,4,0,0,0,0,0,0,3,hypothesis,call_xref_lcalls=1; bb_parent_hits=6
+A04_28.PZU,0x86DE,state_update_worker,1,0,1,12,16,4,0,0,0,0,0,0,3,hypothesis,aux@0x3298/0x32A2; call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x8EAA,unknown,1,0,1,4,2,1,0,0,0,0,0,0,3,hypothesis,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x947A,dispatcher_or_router,8,7,2,5,1,0,0,0,0,0,0,0,3,hypothesis,call_xref_lcalls=2; bb_parent_hits=8
+A03_26.PZU,0x4176,state_reader_or_packet_builder,5,4,0,1,5,0,0,0,0,0,0,0,2,unknown,bb_parent_hits=5
+A03_26.PZU,0x497A,state_update_worker,3,2,0,90,8,5,0,0,0,0,0,0,2,unknown,bb_parent_hits=3
+A03_26.PZU,0x68F9,unknown,1,0,1,0,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x6B58,unknown,1,0,2,0,2,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A03_26.PZU,0x6BA5,unknown,1,0,1,1,2,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x6C3C,unknown,1,0,1,1,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x6D56,unknown,1,0,2,1,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A03_26.PZU,0x6DC7,unknown,1,0,1,1,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x7099,unknown,1,0,2,1,0,1,0,0,0,0,0,0,2,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A03_26.PZU,0x8692,unknown,5,4,1,2,2,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=1; bb_parent_hits=5
+A03_26.PZU,0x8F5B,unknown,1,0,2,2,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A03_26.PZU,0x8FCC,unknown,3,2,2,0,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=2; bb_parent_hits=3
+A03_26.PZU,0x942A,unknown,1,0,2,2,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A03_26.PZU,0x9481,unknown,3,2,2,0,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=2; bb_parent_hits=3
+A03_26.PZU,0x94CE,unknown,2,1,1,1,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=1; bb_parent_hits=2
+A03_26.PZU,0x9EEC,unknown,2,1,2,8,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=2; bb_parent_hits=2
+A03_26.PZU,0xA241,unknown,1,0,13,0,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=13; bb_parent_hits=1
+A03_26.PZU,0xA248,unknown,1,0,1,0,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0xA26E,unknown,1,0,1,16,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x4176,state_reader_or_packet_builder,5,4,0,1,5,0,0,0,0,0,0,0,2,unknown,bb_parent_hits=5
+A04_28.PZU,0x67D1,unknown,1,0,1,0,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x6A30,unknown,1,0,2,0,2,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A04_28.PZU,0x6A7D,unknown,1,0,1,1,2,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x6B14,unknown,1,0,1,2,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x6C2F,unknown,1,0,2,1,1,0,0,0,0,0,0,0,2,unknown,aux@0x3298/0x32A2; call_xref_lcalls=2; bb_parent_hits=1
+A04_28.PZU,0x6CA0,unknown,1,0,1,1,1,0,0,0,0,0,0,0,2,unknown,aux@0x3298/0x32A2; call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x6F6A,unknown,1,0,2,0,0,1,0,0,0,0,0,0,2,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A04_28.PZU,0x8637,unknown,5,4,1,2,2,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=1; bb_parent_hits=5
+A04_28.PZU,0x8EF6,unknown,1,0,2,2,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A04_28.PZU,0x8F67,unknown,3,2,2,0,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=2; bb_parent_hits=3
+A04_28.PZU,0x946B,unknown,1,0,2,2,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A04_28.PZU,0x94C2,unknown,3,2,2,0,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=2; bb_parent_hits=3
+A04_28.PZU,0xA1FA,unknown,2,1,2,8,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=2; bb_parent_hits=2
+A04_28.PZU,0xA625,unknown,1,0,13,0,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=13; bb_parent_hits=1
+A04_28.PZU,0xA62C,unknown,1,0,1,0,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0xA652,unknown,1,0,1,16,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0xADC6,unknown,3,2,1,1,1,0,0,0,0,0,0,0,2,unknown,call_xref_lcalls=1; bb_parent_hits=3
+A03_26.PZU,0x4100,unknown,1,0,0,5,1,0,0,0,0,0,0,0,1,unknown,bb_parent_hits=1
+A03_26.PZU,0x41D0,unknown,3,2,0,1,1,0,0,0,0,0,0,0,1,unknown,bb_parent_hits=3
+A03_26.PZU,0x41E8,unknown,3,2,1,3,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=3
+A03_26.PZU,0x492E,unknown,3,2,0,0,1,0,0,0,0,0,0,0,1,unknown,bb_parent_hits=3
+A03_26.PZU,0x4954,unknown,3,2,0,0,1,0,0,0,0,0,0,0,1,unknown,bb_parent_hits=3
+A03_26.PZU,0x67C3,unknown,3,2,2,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=2; bb_parent_hits=3
+A03_26.PZU,0x67CA,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x67D9,unknown,1,0,2,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A03_26.PZU,0x67E8,unknown,1,0,1,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x680C,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x6824,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x6834,unknown,1,0,2,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A03_26.PZU,0x683F,unknown,1,0,20,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=20; bb_parent_hits=1
+A03_26.PZU,0x68E6,unknown,1,0,3,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=3; bb_parent_hits=1
+A03_26.PZU,0x6913,unknown,1,0,4,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=4; bb_parent_hits=1
+A03_26.PZU,0x691A,unknown,1,0,18,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=18; bb_parent_hits=1
+A03_26.PZU,0x692E,unknown,1,0,2,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A03_26.PZU,0x693B,unknown,1,0,4,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=4; bb_parent_hits=1
+A03_26.PZU,0x694E,unknown,1,0,17,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=17; bb_parent_hits=1
+A03_26.PZU,0x6990,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x6991,unknown,1,0,1,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x699C,unknown,1,0,2,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A03_26.PZU,0x69A3,unknown,1,0,6,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=6; bb_parent_hits=1
+A03_26.PZU,0x69AC,unknown,1,0,1,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x69B7,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x69C6,unknown,3,2,3,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=3; bb_parent_hits=3
+A03_26.PZU,0x69CE,unknown,1,0,5,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=5; bb_parent_hits=1
+A03_26.PZU,0x6A06,unknown,1,0,3,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=3; bb_parent_hits=1
+A03_26.PZU,0x6A15,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x6AE9,unknown,2,1,5,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=5; bb_parent_hits=2
+A03_26.PZU,0x6B0F,unknown,1,0,2,3,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A03_26.PZU,0x6B22,unknown,2,1,6,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=6; bb_parent_hits=2
+A03_26.PZU,0x6B3A,unknown,3,2,3,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=3; bb_parent_hits=3
+A03_26.PZU,0x6B96,unknown,1,0,2,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A03_26.PZU,0x6B99,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x6BA2,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x6C21,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x6D2D,unknown,1,0,2,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A03_26.PZU,0x6D2E,unknown,1,0,33,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=33; bb_parent_hits=1
+A03_26.PZU,0x6D38,unknown,1,0,4,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=4; bb_parent_hits=1
+A03_26.PZU,0x6D5D,unknown,1,0,5,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=5; bb_parent_hits=1
+A03_26.PZU,0x6D6F,unknown,1,0,1,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x6D7E,unknown,1,0,1,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x6D83,unknown,1,0,3,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=3; bb_parent_hits=1
+A03_26.PZU,0x6D88,unknown,1,0,3,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=3; bb_parent_hits=1
+A03_26.PZU,0x708A,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x89EE,unknown,1,0,1,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x89FE,unknown,1,0,1,2,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x8A16,unknown,1,0,1,2,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x8A42,unknown,1,0,1,2,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x8A5E,unknown,1,0,5,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=5; bb_parent_hits=1
+A03_26.PZU,0x8E92,unknown,3,2,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=3
+A03_26.PZU,0x8EF3,unknown,5,4,3,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=3; bb_parent_hits=5
+A03_26.PZU,0x8F01,unknown,4,3,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=4
+A03_26.PZU,0x8F80,unknown,3,2,2,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=2; bb_parent_hits=3
+A03_26.PZU,0x8F9D,unknown,3,2,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=3
+A03_26.PZU,0x93B4,unknown,7,6,1,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=7
+A03_26.PZU,0x941F,unknown,3,2,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=3
+A03_26.PZU,0x9424,unknown,3,2,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=3
+A03_26.PZU,0x948C,unknown,1,0,2,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A03_26.PZU,0x9F29,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A03_26.PZU,0x9F34,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x4100,unknown,1,0,0,5,1,0,0,0,0,0,0,0,1,unknown,bb_parent_hits=1
+A04_28.PZU,0x41D0,unknown,3,2,0,1,1,0,0,0,0,0,0,0,1,unknown,bb_parent_hits=3
+A04_28.PZU,0x41E8,unknown,3,2,1,3,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=3
+A04_28.PZU,0x492E,unknown,3,2,0,0,1,0,0,0,0,0,0,0,1,unknown,bb_parent_hits=3
+A04_28.PZU,0x4954,unknown,3,2,0,0,1,0,0,0,0,0,0,0,1,unknown,bb_parent_hits=3
+A04_28.PZU,0x669B,unknown,3,2,2,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=2; bb_parent_hits=3
+A04_28.PZU,0x66B1,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x66C0,unknown,1,0,1,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x66D4,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x66E4,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x66FC,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x670C,unknown,1,0,2,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A04_28.PZU,0x6717,unknown,1,0,20,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=20; bb_parent_hits=1
+A04_28.PZU,0x67BE,unknown,1,0,3,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=3; bb_parent_hits=1
+A04_28.PZU,0x67D4,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x67EB,unknown,1,0,4,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=4; bb_parent_hits=1
+A04_28.PZU,0x67F2,unknown,1,0,21,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=21; bb_parent_hits=1
+A04_28.PZU,0x6806,unknown,1,0,2,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A04_28.PZU,0x6813,unknown,1,0,4,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=4; bb_parent_hits=1
+A04_28.PZU,0x6826,unknown,1,0,17,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=17; bb_parent_hits=1
+A04_28.PZU,0x6868,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x6869,unknown,1,0,1,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x6874,unknown,1,0,2,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A04_28.PZU,0x687B,unknown,1,0,5,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=5; bb_parent_hits=1
+A04_28.PZU,0x6884,unknown,1,0,1,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x688F,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x689E,unknown,3,2,4,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=4; bb_parent_hits=3
+A04_28.PZU,0x68A6,unknown,1,0,5,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=5; bb_parent_hits=1
+A04_28.PZU,0x68DE,unknown,1,0,3,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=3; bb_parent_hits=1
+A04_28.PZU,0x68ED,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x69C1,unknown,2,1,5,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=5; bb_parent_hits=2
+A04_28.PZU,0x69E7,unknown,1,0,2,3,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A04_28.PZU,0x69FA,unknown,2,1,6,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=6; bb_parent_hits=2
+A04_28.PZU,0x6A12,unknown,3,2,3,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=3; bb_parent_hits=3
+A04_28.PZU,0x6A6E,unknown,1,0,2,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A04_28.PZU,0x6A71,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x6A7A,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x6AF9,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x6C06,unknown,1,0,2,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A04_28.PZU,0x6C07,unknown,1,0,35,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=35; bb_parent_hits=1
+A04_28.PZU,0x6C11,unknown,1,0,4,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=4; bb_parent_hits=1
+A04_28.PZU,0x6C36,unknown,1,0,6,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=6; bb_parent_hits=1
+A04_28.PZU,0x6C48,unknown,1,0,1,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x6C57,unknown,1,0,1,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x6C5C,unknown,1,0,3,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=3; bb_parent_hits=1
+A04_28.PZU,0x6C61,unknown,1,0,3,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=3; bb_parent_hits=1
+A04_28.PZU,0x6F5B,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x8989,unknown,1,0,1,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x8999,unknown,1,0,1,2,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x89B1,unknown,1,0,1,2,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x89DD,unknown,1,0,1,2,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0x89F9,unknown,1,0,5,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=5; bb_parent_hits=1
+A04_28.PZU,0x8E2D,unknown,3,2,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=3
+A04_28.PZU,0x8E8E,unknown,5,4,3,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=3; bb_parent_hits=5
+A04_28.PZU,0x8E9C,unknown,4,3,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=4
+A04_28.PZU,0x8F1B,unknown,3,2,2,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=2; bb_parent_hits=3
+A04_28.PZU,0x8F38,unknown,3,2,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=3
+A04_28.PZU,0x93F7,unknown,7,6,1,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=7
+A04_28.PZU,0x9462,unknown,3,2,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=3
+A04_28.PZU,0x9467,unknown,2,1,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=2
+A04_28.PZU,0x94CD,unknown,1,0,2,1,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=2; bb_parent_hits=1
+A04_28.PZU,0xA237,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1
+A04_28.PZU,0xA242,unknown,1,0,1,0,0,0,0,0,0,0,0,0,1,unknown,call_xref_lcalls=1; bb_parent_hits=1

--- a/scripts/a03_a04_packet_builder_candidates.py
+++ b/scripts/a03_a04_packet_builder_candidates.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Rank A03/A04 packet builder/runtime packet writer candidates."""
+
+from __future__ import annotations
+
+import csv
+from collections import defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+
+FUNCTION_MAP = DOCS / "function_map.csv"
+XDATA_CONFIRMED = DOCS / "xdata_confirmed_access.csv"
+CODE_TABLE_CANDIDATES = DOCS / "code_table_candidates.csv"
+CALL_XREF = DOCS / "call_xref.csv"
+BASIC_BLOCK_MAP = DOCS / "basic_block_map.csv"
+OUT = DOCS / "a03_a04_packet_builder_candidates.csv"
+
+TARGET_BRANCH = "A03_A04"
+TARGET_FILES = {"A03_26.PZU", "A04_28.PZU"}
+
+SNAPSHOT_ADDRS = {0x3110, 0x3128}
+QUEUE_ADDRS = {0x329C}
+SELECTOR_ADDRS = {0x329D}
+PIPELINE_EXTRA_ADDRS = {0x3298, 0x32A2}
+PACKET_XDATA_MIN = 0x5003
+PACKET_XDATA_MAX = 0x5010
+OBJECT_TABLE_BASE = 0x343D
+OBJECT_TABLE_NEAR_RADIUS = 0x10
+
+
+def parse_hex(value: str) -> int:
+    return int(value, 16)
+
+
+def safe_int(value: str) -> int:
+    try:
+        return int(value)
+    except ValueError:
+        return 0
+
+
+def load_csv(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def in_target_scope(row: dict[str, str]) -> bool:
+    return row.get("branch") == TARGET_BRANCH and row.get("file") in TARGET_FILES
+
+
+def find_function(function_ranges: dict[str, list[tuple[int, int, str]]], file_name: str, code_addr: int) -> str | None:
+    for start, end, func_addr in function_ranges.get(file_name, []):
+        if start <= code_addr < end:
+            return func_addr
+    return None
+
+
+def main() -> None:
+    function_rows = [r for r in load_csv(FUNCTION_MAP) if in_target_scope(r)]
+    _ = [r for r in load_csv(CODE_TABLE_CANDIDATES) if in_target_scope(r)]
+    call_rows = [r for r in load_csv(CALL_XREF) if in_target_scope(r)]
+    block_rows = [r for r in load_csv(BASIC_BLOCK_MAP) if in_target_scope(r)]
+    xdata_rows = [r for r in load_csv(XDATA_CONFIRMED) if in_target_scope(r)]
+
+    function_ranges: dict[str, list[tuple[int, int, str]]] = defaultdict(list)
+    metrics: dict[tuple[str, str], dict[str, object]] = {}
+
+    for row in function_rows:
+        file_name = row["file"]
+        faddr = row["function_addr"]
+        start = parse_hex(faddr)
+        size = safe_int(row.get("size_estimate", "0"))
+        end = start + max(size, 1)
+        function_ranges[file_name].append((start, end, faddr))
+        metrics[(file_name, faddr)] = {
+            "file": file_name,
+            "function_addr": faddr,
+            "role_candidate": row.get("role_candidate", "unknown") or "unknown",
+            "basic_block_count": safe_int(row.get("basic_block_count", "0")),
+            "internal_block_count": safe_int(row.get("internal_block_count", "0")),
+            "incoming_lcalls": safe_int(row.get("incoming_lcalls", "0")),
+            "call_count": safe_int(row.get("call_count", "0")),
+            "xdata_read_count": safe_int(row.get("xdata_read_count", "0")),
+            "xdata_write_count": safe_int(row.get("xdata_write_count", "0")),
+            "movc_count": safe_int(row.get("movc_count", "0")),
+            "packet_xdata_hits": 0,
+            "queue_hits": 0,
+            "selector_hits": 0,
+            "snapshot_hits": 0,
+            "object_table_hits": 0,
+            "pipeline_extra_hits": 0,
+            "block_parent_hits": 0,
+            "call_xref_incoming_lcalls": 0,
+            "notes": [],
+        }
+
+    for file_name in function_ranges:
+        function_ranges[file_name].sort(key=lambda x: x[0])
+
+    for row in call_rows:
+        if row.get("call_type") != "LCALL":
+            continue
+        target = row.get("target_addr")
+        key = (row["file"], target)
+        if key in metrics:
+            metrics[key]["call_xref_incoming_lcalls"] = metrics[key]["call_xref_incoming_lcalls"] + 1
+
+    for row in block_rows:
+        parent = row.get("parent_function_candidate")
+        key = (row["file"], parent)
+        if parent and key in metrics:
+            metrics[key]["block_parent_hits"] = metrics[key]["block_parent_hits"] + 1
+
+    for row in xdata_rows:
+        file_name = row["file"]
+        code_addr = parse_hex(row["code_addr"])
+        dptr_addr = parse_hex(row["dptr_addr"])
+        func_addr = find_function(function_ranges, file_name, code_addr)
+        if not func_addr:
+            continue
+        m = metrics[(file_name, func_addr)]
+
+        if PACKET_XDATA_MIN <= dptr_addr <= PACKET_XDATA_MAX:
+            m["packet_xdata_hits"] += 1
+        if dptr_addr in QUEUE_ADDRS:
+            m["queue_hits"] += 1
+        if dptr_addr in SELECTOR_ADDRS:
+            m["selector_hits"] += 1
+        if dptr_addr in SNAPSHOT_ADDRS:
+            m["snapshot_hits"] += 1
+        if abs(dptr_addr - OBJECT_TABLE_BASE) <= OBJECT_TABLE_NEAR_RADIUS:
+            m["object_table_hits"] += 1
+        if dptr_addr in PIPELINE_EXTRA_ADDRS:
+            m["pipeline_extra_hits"] += 1
+
+    out_rows: list[dict[str, str]] = []
+    for m in metrics.values():
+        score = 0
+        if m["packet_xdata_hits"] > 0:
+            score += 3
+        if m["queue_hits"] > 0:
+            score += 3
+        if m["selector_hits"] > 0:
+            score += 3
+        if m["snapshot_hits"] > 0:
+            score += 2
+        if m["object_table_hits"] > 0:
+            score += 2
+        if m["xdata_write_count"] > 0:
+            score += 1
+        if m["xdata_read_count"] > 0:
+            score += 1
+        if m["incoming_lcalls"] > 0:
+            score += 1
+        role = str(m["role_candidate"]).lower()
+        if any(token in role for token in ("packet", "service", "dispatcher")):
+            score += 1
+
+        if score >= 6:
+            confidence = "probable"
+        elif score >= 3:
+            confidence = "hypothesis"
+        else:
+            confidence = "unknown"
+
+        notes = []
+        if m["queue_hits"]:
+            notes.append("queue@0x329C")
+        if m["selector_hits"]:
+            notes.append("selector@0x329D")
+        if m["snapshot_hits"]:
+            notes.append("snapshot@0x3110/0x3128")
+        if m["packet_xdata_hits"]:
+            notes.append("packet_window@0x5003-0x5010")
+        if m["object_table_hits"]:
+            notes.append("object_table_near@0x343D")
+        if m["pipeline_extra_hits"]:
+            notes.append("aux@0x3298/0x32A2")
+        if m["call_xref_incoming_lcalls"]:
+            notes.append(f"call_xref_lcalls={m['call_xref_incoming_lcalls']}")
+        if m["block_parent_hits"]:
+            notes.append(f"bb_parent_hits={m['block_parent_hits']}")
+
+        out_rows.append(
+            {
+                "file": str(m["file"]),
+                "function_addr": str(m["function_addr"]),
+                "role_candidate": str(m["role_candidate"]),
+                "basic_block_count": str(m["basic_block_count"]),
+                "internal_block_count": str(m["internal_block_count"]),
+                "incoming_lcalls": str(m["incoming_lcalls"]),
+                "call_count": str(m["call_count"]),
+                "xdata_read_count": str(m["xdata_read_count"]),
+                "xdata_write_count": str(m["xdata_write_count"]),
+                "movc_count": str(m["movc_count"]),
+                "packet_xdata_hits": str(m["packet_xdata_hits"]),
+                "queue_hits": str(m["queue_hits"]),
+                "selector_hits": str(m["selector_hits"]),
+                "snapshot_hits": str(m["snapshot_hits"]),
+                "object_table_hits": str(m["object_table_hits"]),
+                "score": str(score),
+                "confidence": confidence,
+                "notes": "; ".join(notes),
+            }
+        )
+
+    out_rows.sort(
+        key=lambda r: (
+            -safe_int(r["score"]),
+            -safe_int(r["packet_xdata_hits"]),
+            -safe_int(r["queue_hits"]),
+            -safe_int(r["selector_hits"]),
+            r["file"],
+            parse_hex(r["function_addr"]),
+        )
+    )
+
+    fieldnames = [
+        "file",
+        "function_addr",
+        "role_candidate",
+        "basic_block_count",
+        "internal_block_count",
+        "incoming_lcalls",
+        "call_count",
+        "xdata_read_count",
+        "xdata_write_count",
+        "movc_count",
+        "packet_xdata_hits",
+        "queue_hits",
+        "selector_hits",
+        "snapshot_hits",
+        "object_table_hits",
+        "score",
+        "confidence",
+        "notes",
+    ]
+
+    with OUT.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(out_rows)
+
+    print(f"Wrote {len(out_rows)} rows to {OUT.relative_to(ROOT)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Provide a small, focused ranking step to locate candidate packet_builder / runtime packet-writer functions for the A03_A04 branch (images `A03_26.PZU` and `A04_28.PZU`) to guide next analysis steps. 
- Use existing evidence (function map, xdata hits, call xref, basic block map, code-table candidates) to highlight promising functions without claiming wire-format recovery. 

### Description

- Added `scripts/a03_a04_packet_builder_candidates.py` which reads `docs/function_map.csv`, `docs/xdata_confirmed_access.csv`, `docs/code_table_candidates.csv`, `docs/call_xref.csv`, and `docs/basic_block_map.csv`, restricts analysis to branch `A03_A04` and files `A03_26.PZU`/`A04_28.PZU`, computes hit metrics, applies the requested scoring rules, and writes `docs/a03_a04_packet_builder_candidates.csv`.
- Implemented the requested hit/address checks: `packet_xdata` window `0x5003..0x5010`, `queue` `0x329C`, `selector` `0x329D`, `snapshot` `0x3110`/`0x3128`, `object_table` near `0x343D` (±0x10), and auxiliary addresses `0x3298`/`0x32A2` and counted XDATA read/write hits and block/call evidence.
- Scoring and confidence rules implemented exactly as requested (`+3` packet_xdata/queue/selector, `+2` snapshot/object_table, `+1` for xdata read/write, incoming LCALLs, role keywords), with confidence buckets `probable`/`hypothesis`/`unknown` and intentionally no `confirmed` output.
- Added `docs/a03_a04_packet_builder_analysis.md` documenting scope, the XDATA addresses considered, the top-10 ranked functions (from the generated CSV), which indicators are confirmed vs hypothesis, and suggested next steps; and added one line to `README.md` referencing the new CSV artifact.

### Testing

- Ran `python3 scripts/a03_a04_packet_builder_candidates.py` which executed successfully and wrote `docs/a03_a04_packet_builder_candidates.csv` (212 candidate rows written). (success)
- Ran `wc -l docs/a03_a04_packet_builder_candidates.csv` to verify output size which returned `213` lines (header + 212 rows). (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eda789151083308b36ed28a898b8ba)