### PR TITLE
Add A03/A04 packet-window writer scanner and report

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - `docs/a03_a04_packet_call_neighborhood.csv` — local call-neighborhood around A03/A04 top packet-builder candidates.
 - docs/a03_a04_packet_call_neighborhood_depth2.csv — depth=2 call-neighborhood around A04:0x89C9 and A03:0x8A2E.
 - docs/a03_a04_packet_pipeline_chain_trace.csv — ordered static trace for A03/A04 packet pipeline candidate chains.
+- docs/a03_a04_packet_window_writers.csv — A03/A04 functions with confirmed writes into packet-window 0x5003..0x5010.
 - Предыдущий файл анализа/журнал: `PZU_ANALYSIS.md`
 
 ## Исходные образы

--- a/docs/a03_a04_packet_window_writers.csv
+++ b/docs/a03_a04_packet_window_writers.csv
@@ -1,0 +1,4 @@
+file,branch,function_addr,code_addr,block_addr,xdata_addr,xdata_access_type,role_candidate,incoming_lcalls,call_count,basic_block_count,internal_block_count,nearby_queue_hits,nearby_selector_hits,nearby_aux_hits,nearby_arithmetic_hits,confidence,notes
+A04_28.PZU,A03_A04,0x497A,0x6286,0x498E,0x5004,write,state_update_worker,0,99,3,2,0,0,0,51,probable,static-only: confirmed xdata write in packet-window; arithmetic-near
+A04_28.PZU,A03_A04,0x497A,0x63F4,0x498E,0x5005,write,state_update_worker,0,99,3,2,0,0,0,51,probable,static-only: confirmed xdata write in packet-window; arithmetic-near
+A04_28.PZU,A03_A04,0x89C9,0x89D8,0x89C9,0x500F,write,unknown,1,1,1,0,0,0,0,0,hypothesis,static-only: confirmed xdata write in packet-window

--- a/docs/a03_a04_packet_window_writers.md
+++ b/docs/a03_a04_packet_window_writers.md
@@ -1,0 +1,27 @@
+# A03/A04 packet-window writers (0x5003..0x5010)
+
+## Зачем искали packet-window writers
+Нужен узкий срез функций ветки `A03_A04`, которые делают **confirmed XDATA write** в окно пакета `0x5003..0x5010`, чтобы локализовать места записи marker/packet-полей и сравнить A03 с A04. Это чисто static analysis по CSV-индексам (`function_map`, `basic_block_map`, `disassembly_index`, `xdata_confirmed_access`, `call_xref`), без runtime-доказательства.
+
+## Что найдено
+- `A04_28.PZU`: найдено 2 writer-функции (3 write-события). **[confidence: probable/hypothesis]**
+- `A03_26.PZU`: writer-функций с confirmed write в `0x5003..0x5010` не найдено. **[confidence: probable]**
+
+## Top writers для A04
+1. `0x497A` (`state_update_worker`): writes в `0x5004` и `0x5005`, при этом внутри функции много арифметики (`nearby_arithmetic_hits=51`). **[confidence: probable]**
+2. `0x89C9` (`unknown`): write в `0x500F`, без queue/selector/aux/arith признаков в пределах функции. **[confidence: hypothesis]**
+
+## Top writers для A03
+- В текущем confirmed-наборе нет ни одного write в `0x5003..0x5010` для `A03_26.PZU`. **[confidence: probable]**
+- Это согласуется с предыдущим наблюдением: в цепочке A03 (`0xA900 -> 0x8904 -> 0x8A2E`) видны queue/selector writes (`0x329C/0x329D`), но не найден явный packet-window write в указанном диапазоне. **[confidence: hypothesis]**
+
+## Аналоги A04:0x89C9 в A03
+- Прямого аналога по confirmed write в packet-window пока нет.
+- Ближайшие кандидаты для ручной трассировки — уже известная A03-цепочка (`0x8904`, `0x8A2E`) и ее upstream caller'ы, т.к. в статике они ближе к queue/selector pipeline, но не дают confirmed write в `0x5003..0x5010`. **[confidence: hypothesis]**
+
+## Что трассировать следующими
+1. В A03: caller-окрестность вокруг `0x8904` и `0x8A2E` (включая переходы между internal blocks), чтобы проверить, не выпадает ли write из confirmed-детектора.
+2. В A04: caller/callee-контекст `0x89C9` (write `0x500F`) как эталон короткого packet-window writer-фрагмента.
+3. Сверка reachable/disasm coverage в A03 на окнах, где в A04 присутствуют writes (`0x5004/0x5005/0x500F`).
+
+> Важно: это **static analysis**, не runtime proof packet format и не окончательное восстановление packet pipeline.

--- a/scripts/find_packet_window_writers.py
+++ b/scripts/find_packet_window_writers.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Find A03/A04 functions that confirmed-write packet window 0x5003..0x5010."""
+
+from __future__ import annotations
+
+import csv
+from collections import defaultdict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+
+FUNCTION_MAP = DOCS / "function_map.csv"
+BASIC_BLOCK_MAP = DOCS / "basic_block_map.csv"
+DISASM_INDEX = DOCS / "disassembly_index.csv"
+XDATA_CONFIRMED = DOCS / "xdata_confirmed_access.csv"
+CALL_XREF = DOCS / "call_xref.csv"
+OUT = DOCS / "a03_a04_packet_window_writers.csv"
+
+TARGET_BRANCH = "A03_A04"
+TARGET_FILES = {"A03_26.PZU", "A04_28.PZU"}
+PACKET_MIN = 0x5003
+PACKET_MAX = 0x5010
+QUEUE_ADDRS = {0x329C}
+SELECTOR_ADDRS = {0x329D}
+AUX_ADDRS = {0x3298, 0x3299, 0x32A0, 0x32A1, 0x32A2, 0x4DAC, 0x4DB6, 0x4FD7, 0x4FD8}
+ARITHMETIC_MNEMONICS = {"ADD", "ADDC", "SUBB", "XRL", "ANL", "ORL", "INC", "DEC"}
+
+
+def parse_hex(value: str) -> int:
+    return int(value, 16)
+
+
+def safe_int(value: str) -> int:
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return 0
+
+
+def load_csv(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def in_scope(row: dict[str, str]) -> bool:
+    return row.get("branch") == TARGET_BRANCH and row.get("file") in TARGET_FILES
+
+
+def find_function(function_ranges: dict[str, list[tuple[int, int, str]]], file_name: str, code_addr: int) -> str | None:
+    for start, end, func_addr in function_ranges.get(file_name, []):
+        if start <= code_addr < end:
+            return func_addr
+    return None
+
+
+def find_block(block_starts: dict[tuple[str, str], list[int]], file_name: str, function_addr: str, code_addr: int) -> str:
+    starts = block_starts.get((file_name, function_addr), [])
+    candidate: int | None = None
+    for start in starts:
+        if start <= code_addr:
+            candidate = start
+        else:
+            break
+    return f"0x{candidate:04X}" if candidate is not None else ""
+
+
+def main() -> None:
+    function_rows = [r for r in load_csv(FUNCTION_MAP) if in_scope(r)]
+    block_rows = [r for r in load_csv(BASIC_BLOCK_MAP) if in_scope(r)]
+    disasm_rows = [r for r in load_csv(DISASM_INDEX) if in_scope(r)]
+    xdata_rows = [r for r in load_csv(XDATA_CONFIRMED) if in_scope(r)]
+    call_rows = [r for r in load_csv(CALL_XREF) if in_scope(r)]
+
+    function_ranges: dict[str, list[tuple[int, int, str]]] = defaultdict(list)
+    function_meta: dict[tuple[str, str], dict[str, str]] = {}
+    for row in function_rows:
+        faddr = row["function_addr"]
+        start = parse_hex(faddr)
+        size = max(safe_int(row.get("size_estimate", "0")), 1)
+        function_ranges[row["file"]].append((start, start + size, faddr))
+        function_meta[(row["file"], faddr)] = row
+    for file_name in function_ranges:
+        function_ranges[file_name].sort(key=lambda x: x[0])
+
+    block_starts: dict[tuple[str, str], list[int]] = defaultdict(list)
+    for row in block_rows:
+        parent = row.get("parent_function_candidate", "")
+        if not parent:
+            continue
+        block_starts[(row["file"], parent)].append(parse_hex(row["block_addr"]))
+    for key in list(block_starts.keys()):
+        block_starts[key].sort()
+
+    incoming_lcalls: dict[tuple[str, str], int] = defaultdict(int)
+    for row in call_rows:
+        if row.get("call_type") == "LCALL":
+            incoming_lcalls[(row["file"], row["target_addr"])] += 1
+
+    queue_hits: dict[tuple[str, str], int] = defaultdict(int)
+    selector_hits: dict[tuple[str, str], int] = defaultdict(int)
+    aux_hits: dict[tuple[str, str], int] = defaultdict(int)
+    for row in xdata_rows:
+        code_addr = parse_hex(row["code_addr"])
+        dptr_addr = parse_hex(row["dptr_addr"])
+        func_addr = find_function(function_ranges, row["file"], code_addr)
+        if not func_addr:
+            continue
+        key = (row["file"], func_addr)
+        if dptr_addr in QUEUE_ADDRS:
+            queue_hits[key] += 1
+        if dptr_addr in SELECTOR_ADDRS:
+            selector_hits[key] += 1
+        if dptr_addr in AUX_ADDRS:
+            aux_hits[key] += 1
+
+    arithmetic_hits: dict[tuple[str, str], int] = defaultdict(int)
+    for row in disasm_rows:
+        mnemonic = row.get("mnemonic", "").upper()
+        if mnemonic not in ARITHMETIC_MNEMONICS:
+            continue
+        code_addr = parse_hex(row["code_addr"])
+        func_addr = find_function(function_ranges, row["file"], code_addr)
+        if not func_addr:
+            continue
+        arithmetic_hits[(row["file"], func_addr)] += 1
+
+    out_rows: list[dict[str, str]] = []
+    for row in xdata_rows:
+        if row.get("access_type") != "write":
+            continue
+        xdata_addr = parse_hex(row["dptr_addr"])
+        if not (PACKET_MIN <= xdata_addr <= PACKET_MAX):
+            continue
+
+        file_name = row["file"]
+        code_addr = parse_hex(row["code_addr"])
+        function_addr = find_function(function_ranges, file_name, code_addr)
+        if not function_addr:
+            continue
+        key = (file_name, function_addr)
+        meta = function_meta.get(key, {})
+
+        q_hits = queue_hits.get(key, 0)
+        s_hits = selector_hits.get(key, 0)
+        a_hits = aux_hits.get(key, 0)
+        ar_hits = arithmetic_hits.get(key, 0)
+
+        confidence = "probable" if (q_hits or s_hits or a_hits or ar_hits) else "hypothesis"
+        notes = ["static-only: confirmed xdata write in packet-window"]
+        if q_hits:
+            notes.append("queue-near")
+        if s_hits:
+            notes.append("selector-near")
+        if a_hits:
+            notes.append("aux-near")
+        if ar_hits:
+            notes.append("arithmetic-near")
+
+        out_rows.append(
+            {
+                "file": file_name,
+                "branch": row["branch"],
+                "function_addr": function_addr,
+                "code_addr": f"0x{code_addr:04X}",
+                "block_addr": find_block(block_starts, file_name, function_addr, code_addr),
+                "xdata_addr": f"0x{xdata_addr:04X}",
+                "xdata_access_type": row["access_type"],
+                "role_candidate": meta.get("role_candidate", "unknown") or "unknown",
+                "incoming_lcalls": str(incoming_lcalls.get(key, safe_int(meta.get("incoming_lcalls", "0")))),
+                "call_count": str(safe_int(meta.get("call_count", "0"))),
+                "basic_block_count": str(safe_int(meta.get("basic_block_count", "0"))),
+                "internal_block_count": str(safe_int(meta.get("internal_block_count", "0"))),
+                "nearby_queue_hits": str(q_hits),
+                "nearby_selector_hits": str(s_hits),
+                "nearby_aux_hits": str(a_hits),
+                "nearby_arithmetic_hits": str(ar_hits),
+                "confidence": confidence,
+                "notes": "; ".join(notes),
+            }
+        )
+
+    out_rows.sort(
+        key=lambda r: (
+            r["file"],
+            parse_hex(r["function_addr"]),
+            parse_hex(r["code_addr"]),
+        )
+    )
+
+    fieldnames = [
+        "file",
+        "branch",
+        "function_addr",
+        "code_addr",
+        "block_addr",
+        "xdata_addr",
+        "xdata_access_type",
+        "role_candidate",
+        "incoming_lcalls",
+        "call_count",
+        "basic_block_count",
+        "internal_block_count",
+        "nearby_queue_hits",
+        "nearby_selector_hits",
+        "nearby_aux_hits",
+        "nearby_arithmetic_hits",
+        "confidence",
+        "notes",
+    ]
+
+    with OUT.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(out_rows)
+
+    print(f"Wrote {len(out_rows)} rows to {OUT.relative_to(ROOT)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Локализовать функции ветки `A03_A04` (особенно `A03_26.PZU`) которые делают confirmed XDATA `write` в packet-window `0x5003..0x5010`, чтобы понять, где в A03/A04 могут записываться marker/packet-поля; это продолжение поиска после предыдущего анализа.

### Description
- Добавлен скрипт `scripts/find_packet_window_writers.py`, который читает `docs/function_map.csv`, `docs/basic_block_map.csv`, `docs/disassembly_index.csv`, `docs/xdata_confirmed_access.csv` и `docs/call_xref.csv`, фильтрует по ветке `A03_A04` и файлам `A03_26.PZU`/`A04_28.PZU` и ищет только confirmed XDATA `write` в диапазоне `0x5003..0x5010`.
- Скрипт собирает и выводит требуемые поля (включая `file`, `branch`, `function_addr`, `code_addr`, `block_addr`, `xdata_addr`, `xdata_access_type`, `role_candidate`, `incoming_lcalls`, `call_count`, `basic_block_count`, `internal_block_count`, `nearby_queue_hits`, `nearby_selector_hits`, `nearby_aux_hits`, `nearby_arithmetic_hits`, `confidence`, `notes`) с подсчётом nearby-* в пределах функции и с конфиденс-логикой (`probable`/`hypothesis`).
- Созданы артефакты `docs/a03_a04_packet_window_writers.csv` (CSV с найденными writers) и `docs/a03_a04_packet_window_writers.md` (краткая интерпретация результатов и рекомендации по трассировке), а также добавлена одна строка в `README.md` про новый CSV.
- Внесено минимальное изменение к репозиторию; при этом не редактировались `.PZU` файлы и не изменялись запретные скрипты (`scripts/disasm_8051.py`, `scripts/call_xref.py`, `scripts/function_map.py`, `scripts/basic_block_map.py`), а diff остался небольшим.

### Testing
- Запущен `python3 scripts/find_packet_window_writers.py` и скрипт успешно выполнился и записал результаты в `docs/a03_a04_packet_window_writers.csv` (скрипт вывел сообщение об успешно записанных строках).
- Запущена проверка `wc -l docs/a03_a04_packet_window_writers.csv`, которая вернула `4` строк (заголовок + 3 записи), подтверждающая создание CSV с 3 найденными write-событиями; все 3 записи находятся в `A04_28.PZU`, для `A03_26.PZU` confirmed write в `0x5003..0x5010` не найдено.
- Автоматические проверки завершились успешно (скрипт и подсчёт строк); никаких тестов не упали.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edbf1359fc8330bd8d4684c74d683e)