### PR TITLE
Add script to find structural A03 analogs for A04 packet-window writers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - docs/a03_a04_packet_call_neighborhood_depth2.csv — depth=2 call-neighborhood around A04:0x89C9 and A03:0x8A2E.
 - docs/a03_a04_packet_pipeline_chain_trace.csv — ordered static trace for A03/A04 packet pipeline candidate chains.
 - docs/a03_a04_packet_window_writers.csv — A03/A04 functions with confirmed writes into packet-window 0x5003..0x5010.
+- docs/a03_analogs_for_a04_packet_writers.csv — structural A03 analog candidates for A04 packet-window writer functions.
 - Предыдущий файл анализа/журнал: `PZU_ANALYSIS.md`
 
 ## Исходные образы

--- a/docs/a03_analogs_for_a04_packet_writers.csv
+++ b/docs/a03_analogs_for_a04_packet_writers.csv
@@ -1,0 +1,211 @@
+reference_file,reference_function,a03_file,a03_function,similarity_score,role_candidate,basic_block_count,internal_block_count,call_count,incoming_lcalls,xdata_read_count,xdata_write_count,arithmetic_hits,a03_pipeline_hits,near_known_a03_chain,confidence,notes
+A04_28.PZU,0x497A,A03_26.PZU,0x497A,10.25,state_update_worker,3,2,90,0,8,5,47,0,yes,probable,chain_distance=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x86C5,8.25,state_update_worker,6,5,3,1,7,4,2,0,yes,probable,chain_distance=1; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x810E,7.50,state_update_worker,7,6,3,1,11,4,4,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x8B0B,7.25,state_update_worker,1,0,1,1,19,3,6,1,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; pipeline_xdata_hit; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x7953,7.00,state_update_worker,4,3,4,1,22,6,0,3,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; pipeline_xdata_hit
+A04_28.PZU,0x497A,A03_26.PZU,0x7259,7.00,state_reader_or_packet_builder,1,0,3,1,8,1,1,1,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; pipeline_xdata_hit; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x886D,6.50,dispatcher_or_router,7,6,5,1,8,0,6,4,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1; pipeline_xdata_hit; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x70B3,6.50,state_reader_or_packet_builder,3,2,0,1,11,1,1,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x8741,6.50,state_update_worker,1,0,12,1,16,4,1,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x8FD7,6.50,state_reader_or_packet_builder,3,2,3,2,9,0,0,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=2
+A04_28.PZU,0x497A,A03_26.PZU,0xA900,6.25,state_reader_or_packet_builder,3,2,33,1,14,0,3,1,yes,hypothesis,chain_distance=0; incoming_lcall_xref=1; pipeline_xdata_hit; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x80C3,6.25,state_update_worker,9,8,0,1,5,3,1,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x9F58,6.25,state_reader_or_packet_builder,3,2,31,1,3,1,0,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0x8EB1,6.00,state_reader_or_packet_builder,8,7,2,1,6,0,3,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x8F9D,6.00,unknown,3,2,0,1,0,0,1,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x7339,5.75,state_update_worker,3,2,1,1,39,16,0,5,no,hypothesis,incoming_lcall_xref=1; pipeline_xdata_hit
+A04_28.PZU,0x497A,A03_26.PZU,0x800B,5.50,unknown,5,4,21,1,4,2,4,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x9EEC,5.50,unknown,2,1,8,2,1,0,2,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=2; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x9FD8,5.50,state_reader_or_packet_builder,3,2,8,13,4,0,1,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=13; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x6C7E,5.25,state_reader_or_packet_builder,20,19,3,2,5,0,7,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=2; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x8692,5.25,unknown,5,4,2,1,2,0,2,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0xA248,5.25,unknown,1,0,0,1,1,0,1,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0xA2F5,5.25,state_update_worker,1,0,16,1,23,3,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0x680C,5.00,unknown,1,0,0,1,0,0,1,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x89EE,5.00,unknown,1,0,1,1,0,0,1,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x8A42,5.00,unknown,1,0,2,1,0,0,1,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x8E92,5.00,unknown,3,2,0,1,0,0,2,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x8FCC,5.00,unknown,3,2,0,2,1,0,0,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=2
+A04_28.PZU,0x497A,A03_26.PZU,0x9481,5.00,unknown,3,2,0,2,1,0,0,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=2
+A04_28.PZU,0x497A,A03_26.PZU,0x4176,4.75,state_reader_or_packet_builder,5,4,1,0,5,0,10,0,no,hypothesis,arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x67C3,4.75,unknown,3,2,0,2,0,0,1,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=2; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x6834,4.75,unknown,1,0,0,2,0,0,1,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=2; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x6B3A,4.75,unknown,3,2,0,3,0,0,2,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=3; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x8F80,4.75,unknown,3,2,1,2,0,0,4,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=2; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x94CE,4.75,unknown,2,1,1,1,1,0,1,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x41D0,4.50,unknown,3,2,1,0,1,0,3,0,no,hypothesis,arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x492E,4.50,unknown,3,2,0,0,1,0,3,0,no,hypothesis,arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x4954,4.50,unknown,3,2,0,0,1,0,3,0,no,hypothesis,arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x6913,4.50,unknown,1,0,0,4,0,0,2,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=4; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x8A5E,4.50,unknown,1,0,0,5,0,0,6,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=5; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x8F01,4.50,unknown,4,3,0,1,0,0,1,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x9439,4.50,dispatcher_or_router,8,7,5,2,1,0,4,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=2; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x68F9,4.25,unknown,1,0,0,1,1,0,4,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x6BA5,4.25,unknown,1,0,1,1,2,0,7,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x6C3C,4.25,unknown,1,0,1,1,1,0,4,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x8F0F,4.25,unknown,1,0,4,1,2,1,1,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x8FAF,4.25,unknown,5,4,1,1,2,1,0,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0x67E8,4.00,unknown,1,0,1,1,0,0,1,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x6824,4.00,unknown,1,0,0,1,0,0,0,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0x6A15,4.00,unknown,1,0,0,1,0,0,1,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x6AE9,4.00,unknown,2,1,0,5,0,0,2,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=5; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x6B22,4.00,unknown,2,1,0,6,0,0,2,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=6; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x6B99,4.00,unknown,1,0,0,1,0,0,2,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x6BA2,4.00,unknown,1,0,0,1,0,0,0,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0x6C21,4.00,unknown,1,0,0,1,0,0,3,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x89FE,4.00,unknown,1,0,2,1,0,0,0,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0x8A16,4.00,unknown,1,0,2,1,0,0,0,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0x8F5B,4.00,unknown,1,0,2,2,1,0,4,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=2; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x9424,4.00,unknown,3,2,0,1,0,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0x942A,4.00,unknown,1,0,2,2,1,0,0,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=2
+A04_28.PZU,0x497A,A03_26.PZU,0x68E6,3.75,unknown,1,0,0,3,0,0,6,0,yes,unknown,chain_distance=2; incoming_lcall_xref=3; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x692E,3.75,unknown,1,0,0,2,0,0,4,0,yes,unknown,chain_distance=2; incoming_lcall_xref=2; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x69C6,3.75,unknown,3,2,1,3,0,0,0,0,yes,unknown,chain_distance=2; incoming_lcall_xref=3
+A04_28.PZU,0x497A,A03_26.PZU,0x6B96,3.75,unknown,1,0,0,2,0,0,0,0,yes,unknown,chain_distance=1; incoming_lcall_xref=2
+A04_28.PZU,0x497A,A03_26.PZU,0x8EF3,3.75,unknown,5,4,0,3,0,0,1,0,yes,unknown,chain_distance=2; incoming_lcall_xref=3; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x8904,3.50,dispatcher_or_router,13,12,14,1,15,2,1,17,yes,unknown,chain_distance=0; incoming_lcall_xref=1; pipeline_xdata_hit; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x4100,3.50,unknown,1,0,5,0,1,0,15,0,no,unknown,arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x693B,3.50,unknown,1,0,0,4,0,0,6,0,yes,unknown,chain_distance=2; incoming_lcall_xref=4; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x6D38,3.50,unknown,1,0,0,4,0,0,0,0,yes,unknown,chain_distance=1; incoming_lcall_xref=4
+A04_28.PZU,0x497A,A03_26.PZU,0x93B4,3.50,unknown,7,6,1,1,0,0,2,0,yes,unknown,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x683F,3.25,unknown,1,0,0,20,0,0,8,0,yes,unknown,chain_distance=2; incoming_lcall_xref=20; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x691A,3.25,unknown,1,0,0,18,0,0,2,0,yes,unknown,chain_distance=2; incoming_lcall_xref=18; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x694E,3.25,unknown,1,0,0,17,0,0,8,0,yes,unknown,chain_distance=2; incoming_lcall_xref=17; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x6D8D,3.25,state_reader_or_packet_builder,1,0,2,1,3,0,0,0,no,unknown,incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0x6DC7,3.25,unknown,1,0,1,1,1,0,0,0,yes,unknown,chain_distance=2; incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0xA26E,3.25,unknown,1,0,16,1,1,0,0,0,yes,unknown,chain_distance=2; incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0x41E8,3.00,unknown,3,2,3,1,0,0,0,0,no,unknown,incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0x67CA,3.00,unknown,1,0,0,1,0,0,1,0,no,unknown,incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x6990,3.00,unknown,1,0,0,1,0,0,0,0,yes,unknown,chain_distance=2; incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0x69AC,3.00,unknown,1,0,1,1,0,0,0,0,yes,unknown,chain_distance=2; incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0x6B58,3.00,unknown,1,0,0,2,2,0,0,0,yes,unknown,chain_distance=2; incoming_lcall_xref=2
+A04_28.PZU,0x497A,A03_26.PZU,0x6D56,3.00,unknown,1,0,1,2,1,0,0,0,yes,unknown,chain_distance=2; incoming_lcall_xref=2
+A04_28.PZU,0x497A,A03_26.PZU,0x6D6F,3.00,unknown,1,0,1,1,0,0,0,0,yes,unknown,chain_distance=2; incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0x6D7E,3.00,unknown,1,0,1,1,0,0,0,0,yes,unknown,chain_distance=2; incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0x708A,3.00,unknown,1,0,0,1,0,0,0,0,yes,unknown,chain_distance=2; incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0x941F,3.00,unknown,3,2,0,1,0,0,0,0,no,unknown,incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0x9F29,3.00,unknown,1,0,0,1,0,0,0,0,yes,unknown,chain_distance=2; incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0x9F34,3.00,unknown,1,0,0,1,0,0,0,0,yes,unknown,chain_distance=2; incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0x67D9,2.75,unknown,1,0,0,2,0,0,1,0,no,unknown,incoming_lcall_xref=2; arith_present
+A04_28.PZU,0x497A,A03_26.PZU,0x6B0F,2.75,unknown,1,0,3,2,0,0,0,0,yes,unknown,chain_distance=2; incoming_lcall_xref=2
+A04_28.PZU,0x497A,A03_26.PZU,0x6D2D,2.75,unknown,1,0,0,2,0,0,0,0,yes,unknown,chain_distance=2; incoming_lcall_xref=2
+A04_28.PZU,0x497A,A03_26.PZU,0x6D83,2.75,unknown,1,0,1,3,0,0,0,0,yes,unknown,chain_distance=2; incoming_lcall_xref=3
+A04_28.PZU,0x497A,A03_26.PZU,0x7099,2.75,unknown,1,0,1,2,0,1,0,0,yes,unknown,chain_distance=2; incoming_lcall_xref=2
+A04_28.PZU,0x497A,A03_26.PZU,0x948C,2.75,unknown,1,0,1,2,0,0,0,0,yes,unknown,chain_distance=2; incoming_lcall_xref=2
+A04_28.PZU,0x497A,A03_26.PZU,0x69A3,2.50,unknown,1,0,1,6,0,0,0,0,yes,unknown,chain_distance=2; incoming_lcall_xref=6
+A04_28.PZU,0x497A,A03_26.PZU,0x69CE,2.50,unknown,1,0,1,5,0,0,0,0,yes,unknown,chain_distance=2; incoming_lcall_xref=5
+A04_28.PZU,0x497A,A03_26.PZU,0x6D5D,2.50,unknown,1,0,0,5,0,0,0,0,yes,unknown,chain_distance=2; incoming_lcall_xref=5
+A04_28.PZU,0x497A,A03_26.PZU,0xA241,2.50,unknown,1,0,0,13,1,0,0,0,yes,unknown,chain_distance=2; incoming_lcall_xref=13
+A04_28.PZU,0x497A,A03_26.PZU,0x6D2E,2.25,unknown,1,0,0,33,0,0,0,0,yes,unknown,chain_distance=2; incoming_lcall_xref=33
+A04_28.PZU,0x497A,A03_26.PZU,0x8A2E,2.25,unknown,1,0,1,1,1,1,0,0,yes,unknown,chain_distance=0; incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0x6991,2.00,unknown,1,0,1,1,0,0,0,0,no,unknown,incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0x69B7,2.00,unknown,1,0,0,1,0,0,0,0,no,unknown,incoming_lcall_xref=1
+A04_28.PZU,0x497A,A03_26.PZU,0x699C,1.75,unknown,1,0,0,2,0,0,0,0,no,unknown,incoming_lcall_xref=2
+A04_28.PZU,0x497A,A03_26.PZU,0x6A06,1.75,unknown,1,0,0,3,0,0,0,0,no,unknown,incoming_lcall_xref=3
+A04_28.PZU,0x497A,A03_26.PZU,0x6D88,1.75,unknown,1,0,1,3,0,0,0,0,no,unknown,incoming_lcall_xref=3
+A04_28.PZU,0x89C9,A03_26.PZU,0x89EE,9.25,unknown,1,0,1,1,0,0,1,0,yes,probable,chain_distance=1; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0xA248,9.25,unknown,1,0,0,1,1,0,1,0,yes,probable,chain_distance=1; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x680C,9.00,unknown,1,0,0,1,0,0,1,0,yes,probable,chain_distance=1; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x8A42,9.00,unknown,1,0,2,1,0,0,1,0,yes,probable,chain_distance=1; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x6834,8.75,unknown,1,0,0,2,0,0,1,0,yes,probable,chain_distance=1; incoming_lcall_xref=2; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x7259,8.50,state_reader_or_packet_builder,1,0,3,1,8,1,1,1,yes,probable,chain_distance=2; incoming_lcall_xref=1; pipeline_xdata_hit; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x67E8,8.25,unknown,1,0,1,1,0,0,1,0,yes,probable,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x6824,8.25,unknown,1,0,0,1,0,0,0,0,yes,probable,chain_distance=1; incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0x6913,8.25,unknown,1,0,0,4,0,0,2,0,yes,probable,chain_distance=1; incoming_lcall_xref=4; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x6BA2,8.25,unknown,1,0,0,1,0,0,0,0,yes,probable,chain_distance=1; incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0x89FE,8.25,unknown,1,0,2,1,0,0,0,0,yes,probable,chain_distance=1; incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0x8A16,8.25,unknown,1,0,2,1,0,0,0,0,yes,probable,chain_distance=1; incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0x942A,8.25,unknown,1,0,2,2,1,0,0,0,yes,probable,chain_distance=1; incoming_lcall_xref=2
+A04_28.PZU,0x89C9,A03_26.PZU,0x6A15,8.00,unknown,1,0,0,1,0,0,1,0,yes,probable,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x6B96,8.00,unknown,1,0,0,2,0,0,0,0,yes,probable,chain_distance=1; incoming_lcall_xref=2
+A04_28.PZU,0x89C9,A03_26.PZU,0x6C3C,8.00,unknown,1,0,1,1,1,0,4,0,yes,probable,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x8F0F,8.00,unknown,1,0,4,1,2,1,1,0,yes,probable,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x8F9D,8.00,unknown,3,2,0,1,0,0,1,0,yes,probable,chain_distance=1; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x94CE,8.00,unknown,2,1,1,1,1,0,1,0,yes,probable,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x8B0B,7.75,state_update_worker,1,0,1,1,19,3,6,1,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; pipeline_xdata_hit; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x68F9,7.75,unknown,1,0,0,1,1,0,4,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x6B99,7.75,unknown,1,0,0,1,0,0,2,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x6BA5,7.75,unknown,1,0,1,1,2,0,7,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x6C21,7.75,unknown,1,0,0,1,0,0,3,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x6D38,7.75,unknown,1,0,0,4,0,0,0,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=4
+A04_28.PZU,0x89C9,A03_26.PZU,0x6DC7,7.75,unknown,1,0,1,1,1,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0x8A5E,7.75,unknown,1,0,0,5,0,0,6,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=5; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x9EEC,7.75,unknown,2,1,8,2,1,0,2,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=2; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x69AC,7.50,unknown,1,0,1,1,0,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0x6D56,7.50,unknown,1,0,1,2,1,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=2
+A04_28.PZU,0x89C9,A03_26.PZU,0x6D6F,7.50,unknown,1,0,1,1,0,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0x6D7E,7.50,unknown,1,0,1,1,0,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0x7099,7.50,unknown,1,0,1,2,0,1,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=2
+A04_28.PZU,0x89C9,A03_26.PZU,0x8F5B,7.50,unknown,1,0,2,2,1,0,4,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=2; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x692E,7.25,unknown,1,0,0,2,0,0,4,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=2; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x6990,7.25,unknown,1,0,0,1,0,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0x708A,7.25,unknown,1,0,0,1,0,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0x8692,7.25,unknown,5,4,2,1,2,0,2,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x8FAF,7.25,unknown,5,4,1,1,2,1,0,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0x8FCC,7.25,unknown,3,2,0,2,1,0,0,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=2
+A04_28.PZU,0x89C9,A03_26.PZU,0x9481,7.25,unknown,3,2,0,2,1,0,0,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=2
+A04_28.PZU,0x89C9,A03_26.PZU,0x948C,7.25,unknown,1,0,1,2,0,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=2
+A04_28.PZU,0x89C9,A03_26.PZU,0x9F29,7.25,unknown,1,0,0,1,0,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0x9F34,7.25,unknown,1,0,0,1,0,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0x886D,7.00,dispatcher_or_router,7,6,5,1,8,0,6,4,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1; pipeline_xdata_hit; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x67CA,7.00,unknown,1,0,0,1,0,0,1,0,no,hypothesis,incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x68E6,7.00,unknown,1,0,0,3,0,0,6,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=3; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x693B,7.00,unknown,1,0,0,4,0,0,6,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=4; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x6B58,7.00,unknown,1,0,0,2,2,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=2
+A04_28.PZU,0x89C9,A03_26.PZU,0x6D2D,7.00,unknown,1,0,0,2,0,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=2
+A04_28.PZU,0x89C9,A03_26.PZU,0x6D83,7.00,unknown,1,0,1,3,0,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=3
+A04_28.PZU,0x89C9,A03_26.PZU,0x8A2E,7.00,unknown,1,0,1,1,1,1,0,0,yes,hypothesis,chain_distance=0; incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0x8F01,7.00,unknown,4,3,0,1,0,0,1,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x67C3,6.75,unknown,3,2,0,2,0,0,1,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=2; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x67D9,6.75,unknown,1,0,0,2,0,0,1,0,no,hypothesis,incoming_lcall_xref=2; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x691A,6.75,unknown,1,0,0,18,0,0,2,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=18; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x69A3,6.75,unknown,1,0,1,6,0,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=6
+A04_28.PZU,0x89C9,A03_26.PZU,0x69CE,6.75,unknown,1,0,1,5,0,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=5
+A04_28.PZU,0x89C9,A03_26.PZU,0x6B0F,6.75,unknown,1,0,3,2,0,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=2
+A04_28.PZU,0x89C9,A03_26.PZU,0x8E92,6.75,unknown,3,2,0,1,0,0,2,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x8EB1,6.75,state_reader_or_packet_builder,8,7,2,1,6,0,3,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0xA26E,6.75,unknown,1,0,16,1,1,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0x6991,6.50,unknown,1,0,1,1,0,0,0,0,no,hypothesis,incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0x6AE9,6.50,unknown,2,1,0,5,0,0,2,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=5; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x6B22,6.50,unknown,2,1,0,6,0,0,2,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=6; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x6D5D,6.50,unknown,1,0,0,5,0,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=5
+A04_28.PZU,0x89C9,A03_26.PZU,0x70B3,6.50,state_reader_or_packet_builder,3,2,0,1,11,1,1,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x8F80,6.50,unknown,3,2,1,2,0,0,4,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=2; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x93B4,6.50,unknown,7,6,1,1,0,0,2,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x9439,6.50,dispatcher_or_router,8,7,5,2,1,0,4,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=2; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x9F58,6.50,state_reader_or_packet_builder,3,2,31,1,3,1,0,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0xA241,6.50,unknown,1,0,0,13,1,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=13
+A04_28.PZU,0x89C9,A03_26.PZU,0x683F,6.25,unknown,1,0,0,20,0,0,8,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=20; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x694E,6.25,unknown,1,0,0,17,0,0,8,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=17; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x69B7,6.25,unknown,1,0,0,1,0,0,0,0,no,hypothesis,incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0x6B3A,6.25,unknown,3,2,0,3,0,0,2,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=3; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x6D2E,6.25,unknown,1,0,0,33,0,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=33
+A04_28.PZU,0x89C9,A03_26.PZU,0x86C5,6.25,state_update_worker,6,5,3,1,7,4,2,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x8741,6.25,state_update_worker,1,0,12,1,16,4,1,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x9424,6.25,unknown,3,2,0,1,0,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0x41D0,6.00,unknown,3,2,1,0,1,0,3,0,no,hypothesis,arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x699C,6.00,unknown,1,0,0,2,0,0,0,0,no,hypothesis,incoming_lcall_xref=2
+A04_28.PZU,0x89C9,A03_26.PZU,0x69C6,6.00,unknown,3,2,1,3,0,0,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=3
+A04_28.PZU,0x89C9,A03_26.PZU,0x6D88,6.00,unknown,1,0,1,3,0,0,0,0,no,hypothesis,incoming_lcall_xref=3
+A04_28.PZU,0x89C9,A03_26.PZU,0x6D8D,6.00,state_reader_or_packet_builder,1,0,2,1,3,0,0,0,no,hypothesis,incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0x800B,6.00,unknown,5,4,21,1,4,2,4,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x8EF3,6.00,unknown,5,4,0,3,0,0,1,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=3; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x8FD7,6.00,state_reader_or_packet_builder,3,2,3,2,9,0,0,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=2
+A04_28.PZU,0x89C9,A03_26.PZU,0x7953,5.75,state_update_worker,4,3,4,1,22,6,0,3,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; pipeline_xdata_hit
+A04_28.PZU,0x89C9,A03_26.PZU,0x4100,5.75,unknown,1,0,5,0,1,0,15,0,no,hypothesis,arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x492E,5.75,unknown,3,2,0,0,1,0,3,0,no,hypothesis,arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x4954,5.75,unknown,3,2,0,0,1,0,3,0,no,hypothesis,arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x6A06,5.75,unknown,1,0,0,3,0,0,0,0,no,hypothesis,incoming_lcall_xref=3
+A04_28.PZU,0x89C9,A03_26.PZU,0x810E,5.75,state_update_worker,7,6,3,1,11,4,4,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x6C7E,5.50,state_reader_or_packet_builder,20,19,3,2,5,0,7,0,yes,hypothesis,chain_distance=1; incoming_lcall_xref=2; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0xA2F5,5.50,state_update_worker,1,0,16,1,23,3,0,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0xA900,5.25,state_reader_or_packet_builder,3,2,33,1,14,0,3,1,yes,hypothesis,chain_distance=0; incoming_lcall_xref=1; pipeline_xdata_hit; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x497A,5.25,state_update_worker,3,2,90,0,8,5,47,0,yes,hypothesis,chain_distance=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x80C3,5.25,state_update_worker,9,8,0,1,5,3,1,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=1; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x941F,5.25,unknown,3,2,0,1,0,0,0,0,no,hypothesis,incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0x9FD8,5.25,state_reader_or_packet_builder,3,2,8,13,4,0,1,0,yes,hypothesis,chain_distance=2; incoming_lcall_xref=13; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x7339,5.00,state_update_worker,3,2,1,1,39,16,0,5,no,hypothesis,incoming_lcall_xref=1; pipeline_xdata_hit
+A04_28.PZU,0x89C9,A03_26.PZU,0x41E8,5.00,unknown,3,2,3,1,0,0,0,0,no,hypothesis,incoming_lcall_xref=1
+A04_28.PZU,0x89C9,A03_26.PZU,0x8904,4.50,dispatcher_or_router,13,12,14,1,15,2,1,17,yes,hypothesis,chain_distance=0; incoming_lcall_xref=1; pipeline_xdata_hit; arith_present
+A04_28.PZU,0x89C9,A03_26.PZU,0x4176,4.25,state_reader_or_packet_builder,5,4,1,0,5,0,10,0,no,hypothesis,arith_present

--- a/docs/a03_analogs_for_a04_packet_writers.md
+++ b/docs/a03_analogs_for_a04_packet_writers.md
@@ -1,0 +1,31 @@
+# A03 analogs for A04 packet-window writer functions
+
+Этот документ нужен, чтобы выбрать функции A03 для следующей трассировки, когда в A03 нет confirmed write в 0x5003..0x5010.
+
+Прямого совпадения по write в packet-window недостаточно: часть логики может быть вынесена в соседние worker/dispatcher функции, поэтому мы используем structural similarity по function-map, xdata-паттернам и call-neighborhood.
+
+### Top A03 candidates for A04:0x497A
+- A03:0x497A score=10.25 confidence=probable pipeline_hits=0 near_chain=yes role=state_update_worker
+- A03:0x86C5 score=8.25 confidence=probable pipeline_hits=0 near_chain=yes role=state_update_worker
+- A03:0x810E score=7.50 confidence=hypothesis pipeline_hits=0 near_chain=yes role=state_update_worker
+- A03:0x8B0B score=7.25 confidence=hypothesis pipeline_hits=1 near_chain=yes role=state_update_worker
+- A03:0x7953 score=7.00 confidence=hypothesis pipeline_hits=3 near_chain=yes role=state_update_worker
+
+### Top A03 candidates for A04:0x89C9
+- A03:0x89EE score=9.25 confidence=probable pipeline_hits=0 near_chain=yes role=unknown
+- A03:0xA248 score=9.25 confidence=probable pipeline_hits=0 near_chain=yes role=unknown
+- A03:0x680C score=9.00 confidence=probable pipeline_hits=0 near_chain=yes role=unknown
+- A03:0x8A42 score=9.00 confidence=probable pipeline_hits=0 near_chain=yes role=unknown
+- A03:0x6834 score=8.75 confidence=probable pipeline_hits=0 near_chain=yes role=unknown
+
+## Связь с цепочкой A03 0xA900 -> 0x8904 -> 0x8A2E
+
+- Метка `near_known_a03_chain=yes` означает расстояние в call-neighborhood <=2 от этой цепочки.
+- Это индикатор приоритета трассировки, но не доказательство packet format.
+
+## Следующие кандидаты для трассировки
+
+- В первую очередь: кандидаты `confidence=probable` и `near_known_a03_chain=yes`.
+- Затем: `confidence=hypothesis` с ненулевым `a03_pipeline_hits`.
+
+**Важно:** это structural similarity analysis, не финальное доказательство соответствия packet формату.

--- a/scripts/find_a03_analogs_for_a04_writers.py
+++ b/scripts/find_a03_analogs_for_a04_writers.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Find structural A03 analogs for A04 packet-window writer functions."""
+
+from __future__ import annotations
+
+import csv
+from collections import defaultdict, deque
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+
+FUNCTION_MAP = DOCS / "function_map.csv"
+BASIC_BLOCK_MAP = DOCS / "basic_block_map.csv"
+DISASM_INDEX = DOCS / "disassembly_index.csv"
+XDATA_CONFIRMED = DOCS / "xdata_confirmed_access.csv"
+CALL_XREF = DOCS / "call_xref.csv"
+PACKET_WRITERS = DOCS / "a03_a04_packet_window_writers.csv"
+
+OUT_CSV = DOCS / "a03_analogs_for_a04_packet_writers.csv"
+OUT_MD = DOCS / "a03_analogs_for_a04_packet_writers.md"
+
+BRANCH = "A03_A04"
+A03_FILE = "A03_26.PZU"
+A04_FILE = "A04_28.PZU"
+A04_REFERENCES = {"0x497A", "0x89C9"}
+PIPELINE_ADDRS = {0x3298, 0x3299, 0x329C, 0x329D, 0x4DB6, 0x4FD7, 0x4FD8}
+CHAIN_ADDRS = {0x8904, 0x8A2E, 0xA900}
+ARITH_MNEMONICS = {"ADD", "ADDC", "SUBB", "XRL", "ANL", "ORL", "INC", "DEC"}
+
+
+def load_csv(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8", newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def parse_hex(value: str) -> int:
+    return int(value, 16)
+
+
+def safe_int(value: str) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return 0
+
+
+def tokenize_role(role: str) -> set[str]:
+    return {t for t in role.lower().replace("-", "_").split("_") if t and t != "unknown"}
+
+
+def close_score(a: int, b: int) -> float:
+    diff = abs(a - b)
+    if diff == 0:
+        return 1.0
+    if diff <= 1:
+        return 0.75
+    if diff <= 3:
+        return 0.5
+    if diff <= 7:
+        return 0.25
+    return 0.0
+
+
+def get_confidence(score: float) -> str:
+    if score >= 8:
+        return "probable"
+    if score >= 4:
+        return "hypothesis"
+    return "unknown"
+
+
+def main() -> None:
+    function_rows = [r for r in load_csv(FUNCTION_MAP) if r.get("branch") == BRANCH]
+    _ = [r for r in load_csv(BASIC_BLOCK_MAP) if r.get("branch") == BRANCH]
+    disasm_rows = [r for r in load_csv(DISASM_INDEX) if r.get("branch") == BRANCH]
+    xdata_rows = [r for r in load_csv(XDATA_CONFIRMED) if r.get("branch") == BRANCH]
+    call_rows = [r for r in load_csv(CALL_XREF) if r.get("branch") == BRANCH and r.get("call_type") == "LCALL"]
+    writer_rows = [r for r in load_csv(PACKET_WRITERS) if r.get("branch") == BRANCH and r.get("file") == A04_FILE]
+
+    functions: dict[tuple[str, str], dict[str, object]] = {}
+    ranges: dict[str, list[tuple[int, int, str]]] = defaultdict(list)
+
+    for row in function_rows:
+        key = (row["file"], row["function_addr"])
+        start = parse_hex(row["function_addr"])
+        size = max(safe_int(row.get("size_estimate", "0")), 1)
+        ranges[row["file"]].append((start, start + size, row["function_addr"]))
+        functions[key] = {
+            "file": row["file"],
+            "function_addr": row["function_addr"],
+            "role_candidate": row.get("role_candidate", "unknown") or "unknown",
+            "basic_block_count": safe_int(row.get("basic_block_count", "0")),
+            "internal_block_count": safe_int(row.get("internal_block_count", "0")),
+            "call_count": safe_int(row.get("call_count", "0")),
+            "incoming_lcalls": safe_int(row.get("incoming_lcalls", "0")),
+            "xdata_read_count": safe_int(row.get("xdata_read_count", "0")),
+            "xdata_write_count": safe_int(row.get("xdata_write_count", "0")),
+            "arithmetic_hits": 0,
+            "a03_pipeline_hits": 0,
+            "near_known_a03_chain": "no",
+        }
+
+    for file_name in ranges:
+        ranges[file_name].sort(key=lambda x: x[0])
+
+    def find_function(file_name: str, code_addr: int) -> str | None:
+        for start, end, faddr in ranges.get(file_name, []):
+            if start <= code_addr < end:
+                return faddr
+        return None
+
+    for row in disasm_rows:
+        file_name = row["file"]
+        faddr = find_function(file_name, parse_hex(row["code_addr"]))
+        if not faddr:
+            continue
+        if row.get("mnemonic", "").upper() in ARITH_MNEMONICS:
+            functions[(file_name, faddr)]["arithmetic_hits"] += 1
+
+    for row in xdata_rows:
+        file_name = row["file"]
+        faddr = find_function(file_name, parse_hex(row["code_addr"]))
+        if not faddr:
+            continue
+        if parse_hex(row["dptr_addr"]) in PIPELINE_ADDRS:
+            functions[(file_name, faddr)]["a03_pipeline_hits"] += 1
+
+    adj: dict[int, set[int]] = defaultdict(set)
+    incoming_counts: dict[int, int] = defaultdict(int)
+    for row in call_rows:
+        if row["file"] != A03_FILE:
+            continue
+        src = parse_hex(row["code_addr"])
+        dst = parse_hex(row["target_addr"])
+        src_f = find_function(A03_FILE, src)
+        if not src_f:
+            continue
+        src_fn = parse_hex(src_f)
+        adj[src_fn].add(dst)
+        adj[dst].add(src_fn)
+        incoming_counts[dst] += 1
+
+    dist: dict[int, int] = {}
+    dq: deque[int] = deque()
+    for addr in CHAIN_ADDRS:
+        dist[addr] = 0
+        dq.append(addr)
+    while dq:
+        cur = dq.popleft()
+        for nxt in adj.get(cur, set()):
+            if nxt not in dist:
+                dist[nxt] = dist[cur] + 1
+                dq.append(nxt)
+
+    a04_ref: dict[str, dict[str, object]] = {}
+    for row in writer_rows:
+        f = row["function_addr"]
+        if f not in A04_REFERENCES or f in a04_ref:
+            continue
+        a04_ref[f] = {
+            "role_candidate": row.get("role_candidate", "unknown") or "unknown",
+            "basic_block_count": safe_int(row.get("basic_block_count", "0")),
+            "internal_block_count": safe_int(row.get("internal_block_count", "0")),
+            "call_count": safe_int(row.get("call_count", "0")),
+            "incoming_lcalls": safe_int(row.get("incoming_lcalls", "0")),
+            "xdata_read_count": functions[(A04_FILE, f)]["xdata_read_count"],
+            "xdata_write_count": functions[(A04_FILE, f)]["xdata_write_count"],
+            "arithmetic_hits": safe_int(row.get("nearby_arithmetic_hits", "0")),
+        }
+
+    rows_out: list[dict[str, str]] = []
+    for (file_name, faddr), m in functions.items():
+        if file_name != A03_FILE:
+            continue
+        fn_int = parse_hex(faddr)
+        min_dist = dist.get(fn_int, 99)
+        near_chain = "yes" if min_dist <= 2 else "no"
+        m["near_known_a03_chain"] = near_chain
+
+        for ref_fn, ref in sorted(a04_ref.items(), key=lambda x: parse_hex(x[0])):
+            score = 0.0
+            role = str(m["role_candidate"])
+            ref_role = str(ref["role_candidate"])
+            if role == ref_role and role != "unknown":
+                score += 2.0
+            else:
+                overlap = tokenize_role(role) & tokenize_role(ref_role)
+                if overlap:
+                    score += 1.0
+
+            for k in [
+                "basic_block_count",
+                "internal_block_count",
+                "call_count",
+                "incoming_lcalls",
+                "xdata_read_count",
+                "xdata_write_count",
+                "arithmetic_hits",
+            ]:
+                score += close_score(int(m[k]), int(ref[k]))
+
+            if int(m["a03_pipeline_hits"]) > 0:
+                score += 1.0
+            if int(m["arithmetic_hits"]) > 0:
+                score += 1.0
+            if min_dist == 1:
+                score += 2.0
+            elif min_dist == 2:
+                score += 1.0
+
+            notes = []
+            if min_dist <= 2:
+                notes.append(f"chain_distance={min_dist}")
+            if incoming_counts.get(fn_int, 0):
+                notes.append(f"incoming_lcall_xref={incoming_counts[fn_int]}")
+            if int(m["a03_pipeline_hits"]):
+                notes.append("pipeline_xdata_hit")
+            if int(m["arithmetic_hits"]):
+                notes.append("arith_present")
+
+            rows_out.append(
+                {
+                    "reference_file": A04_FILE,
+                    "reference_function": ref_fn,
+                    "a03_file": A03_FILE,
+                    "a03_function": faddr,
+                    "similarity_score": f"{score:.2f}",
+                    "role_candidate": str(m["role_candidate"]),
+                    "basic_block_count": str(m["basic_block_count"]),
+                    "internal_block_count": str(m["internal_block_count"]),
+                    "call_count": str(m["call_count"]),
+                    "incoming_lcalls": str(m["incoming_lcalls"]),
+                    "xdata_read_count": str(m["xdata_read_count"]),
+                    "xdata_write_count": str(m["xdata_write_count"]),
+                    "arithmetic_hits": str(m["arithmetic_hits"]),
+                    "a03_pipeline_hits": str(m["a03_pipeline_hits"]),
+                    "near_known_a03_chain": near_chain,
+                    "confidence": get_confidence(score),
+                    "notes": "; ".join(notes),
+                }
+            )
+
+    rows_out.sort(
+        key=lambda r: (
+            r["reference_function"],
+            -float(r["similarity_score"]),
+            -safe_int(r["a03_pipeline_hits"]),
+            r["a03_function"],
+        )
+    )
+
+    fieldnames = [
+        "reference_file",
+        "reference_function",
+        "a03_file",
+        "a03_function",
+        "similarity_score",
+        "role_candidate",
+        "basic_block_count",
+        "internal_block_count",
+        "call_count",
+        "incoming_lcalls",
+        "xdata_read_count",
+        "xdata_write_count",
+        "arithmetic_hits",
+        "a03_pipeline_hits",
+        "near_known_a03_chain",
+        "confidence",
+        "notes",
+    ]
+    with OUT_CSV.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows_out)
+
+    top_by_ref: dict[str, list[dict[str, str]]] = defaultdict(list)
+    for row in rows_out:
+        if len(top_by_ref[row["reference_function"]]) < 8:
+            top_by_ref[row["reference_function"]].append(row)
+
+    def render_top(ref_fn: str) -> str:
+        lines = [f"### Top A03 candidates for A04:{ref_fn}"]
+        for row in top_by_ref.get(ref_fn, [])[:5]:
+            lines.append(
+                "- "
+                f"A03:{row['a03_function']} score={row['similarity_score']} confidence={row['confidence']} "
+                f"pipeline_hits={row['a03_pipeline_hits']} near_chain={row['near_known_a03_chain']} "
+                f"role={row['role_candidate']}"
+            )
+        return "\n".join(lines)
+
+    md = f"""# A03 analogs for A04 packet-window writer functions
+
+Этот документ нужен, чтобы выбрать функции A03 для следующей трассировки, когда в A03 нет confirmed write в 0x5003..0x5010.
+
+Прямого совпадения по write в packet-window недостаточно: часть логики может быть вынесена в соседние worker/dispatcher функции, поэтому мы используем structural similarity по function-map, xdata-паттернам и call-neighborhood.
+
+{render_top('0x497A')}
+
+{render_top('0x89C9')}
+
+## Связь с цепочкой A03 0xA900 -> 0x8904 -> 0x8A2E
+
+- Метка `near_known_a03_chain=yes` означает расстояние в call-neighborhood <=2 от этой цепочки.
+- Это индикатор приоритета трассировки, но не доказательство packet format.
+
+## Следующие кандидаты для трассировки
+
+- В первую очередь: кандидаты `confidence=probable` и `near_known_a03_chain=yes`.
+- Затем: `confidence=hypothesis` с ненулевым `a03_pipeline_hits`.
+
+**Важно:** это structural similarity analysis, не финальное доказательство соответствия packet формату.
+"""
+    OUT_MD.write_text(md, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- В A04 найдены writer-функции `0x497A` и `0x89C9`, а в A03 нет подтверждённых записей в `0x5003..0x5010`, поэтому требуется искать A03-аналоги по структуре и паттернам XDATA/вызовов, а не только по адресу записи.
- Нужен лёгкий скрипт для ранжирования всех функций `A03_26.PZU` относительно A04-референсов по множеству признаков, чтобы выбрать кандидатов для следующей трассировки.

### Description
- Добавлен новый скрипт `scripts/find_a03_analogs_for_a04_writers.py`, который читает `docs/function_map.csv`, `docs/basic_block_map.csv`, `docs/disassembly_index.csv`, `docs/xdata_confirmed_access.csv`, `docs/call_xref.csv` и `docs/a03_a04_packet_window_writers.csv` и рассчитывает similarity score для каждой функции `A03_26.PZU` относительно A04-референсов `0x497A` и `0x89C9`.
- Учтены признаки: совпадение/перекрытие `role_candidate`, `basic_block_count`, `internal_block_count`, `call_count`, `incoming_lcalls`, `xdata_read_count`, `xdata_write_count`, `nearby_arithmetic_hits`, обращения к A03 pipeline-адресам (`0x3298,0x3299,0x329C,0x329D,0x4DB6,0x4FD7,0x4FD8`), наличие арифметики (ADD/ADDC/SUBB/XRL/ANL/ORL/INC/DEC) и близость в call-neighborhood к цепочке `0xA900 -> 0x8904 -> 0x8A2E`.
- Скрипт генерирует `docs/a03_analogs_for_a04_packet_writers.csv` с колонками `reference_file,reference_function,a03_file,a03_function,similarity_score,role_candidate,basic_block_count,internal_block_count,call_count,incoming_lcalls,xdata_read_count,xdata_write_count,arithmetic_hits,a03_pipeline_hits,near_known_a03_chain,confidence,notes` и `docs/a03_analogs_for_a04_packet_writers.md` с кратким rationale и топ-кандидатами для обеих reference-функций; добавлена одна строка в `README.md` про новый CSV.
- Confidence выставляется только как `probable|hypothesis|unknown` по общей оценке, и в документах явно указано, что это structural similarity, а не подтверждение соответствия packet формату; `.PZU` файлы и существующие анализ-скрипты не изменялись.

### Testing
- Запущен `python3 scripts/find_a03_analogs_for_a04_writers.py` и выполнение завершилось успешно.
- Подтверждён вывод файла: `wc -l docs/a03_analogs_for_a04_packet_writers.csv` вернул `211` строк, что соответствует созданному CSV; обе проверки прошли успешно.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edc1415da8833098c45a1b7c8ca392)