### PR TITLE
Add experimental 8051 function-level firmware sandbox MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,3 +241,12 @@ python3 scripts/project_guided_mds_mvk_valve_output_analyzer.py
 python3 scripts/project_guided_static_summary_builder.py
 python3 scripts/run_analysis_smoke_test.py
 ```
+
+## Firmware execution sandbox / experimental emulator
+
+- `emulator/README.md`
+- `docs/emulator/firmware_execution_sandbox_report.md`
+- `docs/emulator/function_trace_summary.csv`
+- `docs/emulator/xdata_write_trace.csv`
+- `docs/emulator/candidate_packet_records.csv`
+- `docs/emulator/emulation_limitations.md`

--- a/docs/emulator/candidate_packet_records.csv
+++ b/docs/emulator/candidate_packet_records.csv
@@ -1,0 +1,2 @@
+run_id,scenario,function_addr,record_base,record_bytes,source_xdata_addrs,possible_role,confidence,evidence_level,notes
+packet_bridge_default_5602_20260427T165433Z,packet_bridge_default,0x5602,0x0000,1,0x0000,unknown_record,low,emulation_observed,Grouped contiguous observed XDATA writes only; format not decoded.

--- a/docs/emulator/emulation_limitations.md
+++ b/docs/emulator/emulation_limitations.md
@@ -1,0 +1,7 @@
+# Emulation limitations (experimental sandbox)
+
+- This is **not** a full CPU/hardware emulator.
+- UART/SFR mapping is not confirmed; no confirmed RS-485 decoder exists in this sandbox.
+- Interrupt/timer behavior is not modeled with hardware fidelity.
+- Some target functions may stop early due to unsupported opcodes or unknown hardware dependencies.
+- Results are constrained scenario observations (`emulation_observed`) and do not imply real-device behavior without bench validation.

--- a/docs/emulator/firmware_execution_sandbox_report.md
+++ b/docs/emulator/firmware_execution_sandbox_report.md
@@ -1,0 +1,26 @@
+# Firmware execution sandbox report
+
+## Scope
+Experimental function-level 8051-subset tracing for selected targets. Evidence level: emulation_observed.
+
+## CPU subset status
+Implemented subset includes MOV/MOVX/DPTR ops, simple ALU immediates, limited branches, LCALL/LJMP/RET.
+Unsupported opcodes are logged and never silently ignored.
+
+## Loaded firmware/artifact source
+90CYE03_19_DKS.PZU via pzu_intel_hex
+
+## Target functions tested
+Scenario: packet_bridge_default
+Functions: 0x55AD, 0x5602, 0x5A7F
+
+## Unsupported opcodes encountered
+3
+
+## XDATA writes observed
+1
+
+## Candidate packet/event records
+See docs/emulator/candidate_packet_records.csv (contiguous observed writes only; no packet format invention).
+
+No real RS-485 command is confirmed unless UART/SBUF writes or decoded packet bytes are observed.

--- a/docs/emulator/function_trace_summary.csv
+++ b/docs/emulator/function_trace_summary.csv
@@ -1,0 +1,4 @@
+run_id,scenario,firmware_file,function_addr,steps,stop_reason,calls_seen,returns_seen,xdata_reads,xdata_writes,unsupported_ops,confidence,notes
+packet_bridge_default_55AD_20260427T165433Z,packet_bridge_default,90CYE03_19_DKS.PZU,0x55AD,4,unsupported_opcode 0x08 at 0x55CF,1,1,1,0,1,low,emulation_observed
+packet_bridge_default_5602_20260427T165433Z,packet_bridge_default,90CYE03_19_DKS.PZU,0x5602,4,unsupported_opcode 0x09 at 0x5607,1,1,0,1,1,low,emulation_observed
+packet_bridge_default_5A7F_20260427T165433Z,packet_bridge_default,90CYE03_19_DKS.PZU,0x5A7F,1,unsupported_opcode 0x25 at 0x5A7F,0,0,0,0,1,low,emulation_observed

--- a/docs/emulator/trace_packet_bridge_default_55AD_20260427T165429Z.csv
+++ b/docs/emulator/trace_packet_bridge_default_55AD_20260427T165429Z.csv
@@ -1,0 +1,8 @@
+run_id,firmware_file,function_addr,step,pc,op,args,acc_before,acc_after,dptr_before,dptr_after,r0,r1,r2,r3,r4,r5,r6,r7,xdata_addr,xdata_value,trace_type,notes
+packet_bridge_default_55AD_20260427T165429Z,90CYE03_19_DKS.PZU,0x55AD,1,0x55AD,LCALL,0x5A7F,,,,,,,,,,,,,,,call,
+packet_bridge_default_55AD_20260427T165429Z,90CYE03_19_DKS.PZU,0x55AD,1,0x55B0,RET(stub),0x5A7F,,,,,,,,,,,,,,,ret,
+packet_bridge_default_55AD_20260427T165429Z,90CYE03_19_DKS.PZU,0x55AD,1,0x55AD,LCALL,0x5A7F,0x00,0x00,0x0000,0x0000,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,,,instruction,
+packet_bridge_default_55AD_20260427T165429Z,90CYE03_19_DKS.PZU,0x55AD,2,0x55B0,MOVX,"A,@DPTR",0x00,0x00,0x0000,0x0000,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,,,instruction,watchpoint_hit=False
+packet_bridge_default_55AD_20260427T165429Z,90CYE03_19_DKS.PZU,0x55AD,2,0x55B0,MOVX,"A,@DPTR",,,,,,,,,,,,,0x0000,0x00,xdata_read,watchpoint_hit=False
+packet_bridge_default_55AD_20260427T165429Z,90CYE03_19_DKS.PZU,0x55AD,3,0x55B1,CJNE,"A,#0x01,27",0x00,0x00,0x0000,0x0000,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,,,instruction,
+packet_bridge_default_55AD_20260427T165429Z,90CYE03_19_DKS.PZU,0x55AD,4,0x55CF,0x08,,,,,,,,,,,,,,,,unsupported_opcode,unsupported_opcode 0x08 at 0x55CF

--- a/docs/emulator/trace_packet_bridge_default_55AD_20260427T165433Z.csv
+++ b/docs/emulator/trace_packet_bridge_default_55AD_20260427T165433Z.csv
@@ -1,0 +1,8 @@
+run_id,firmware_file,function_addr,step,pc,op,args,acc_before,acc_after,dptr_before,dptr_after,r0,r1,r2,r3,r4,r5,r6,r7,xdata_addr,xdata_value,trace_type,notes
+packet_bridge_default_55AD_20260427T165433Z,90CYE03_19_DKS.PZU,0x55AD,1,0x55AD,LCALL,0x5A7F,,,,,,,,,,,,,,,call,
+packet_bridge_default_55AD_20260427T165433Z,90CYE03_19_DKS.PZU,0x55AD,1,0x55B0,RET(stub),0x5A7F,,,,,,,,,,,,,,,ret,
+packet_bridge_default_55AD_20260427T165433Z,90CYE03_19_DKS.PZU,0x55AD,1,0x55AD,LCALL,0x5A7F,0x00,0x00,0x0000,0x0000,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,,,instruction,
+packet_bridge_default_55AD_20260427T165433Z,90CYE03_19_DKS.PZU,0x55AD,2,0x55B0,MOVX,"A,@DPTR",0x00,0x00,0x0000,0x0000,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,,,instruction,watchpoint_hit=False
+packet_bridge_default_55AD_20260427T165433Z,90CYE03_19_DKS.PZU,0x55AD,2,0x55B0,MOVX,"A,@DPTR",,,,,,,,,,,,,0x0000,0x00,xdata_read,watchpoint_hit=False
+packet_bridge_default_55AD_20260427T165433Z,90CYE03_19_DKS.PZU,0x55AD,3,0x55B1,CJNE,"A,#0x01,27",0x00,0x00,0x0000,0x0000,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,,,instruction,
+packet_bridge_default_55AD_20260427T165433Z,90CYE03_19_DKS.PZU,0x55AD,4,0x55CF,0x08,,,,,,,,,,,,,,,,unsupported_opcode,unsupported_opcode 0x08 at 0x55CF

--- a/docs/emulator/trace_packet_bridge_default_5602_20260427T165429Z.csv
+++ b/docs/emulator/trace_packet_bridge_default_5602_20260427T165429Z.csv
@@ -1,0 +1,8 @@
+run_id,firmware_file,function_addr,step,pc,op,args,acc_before,acc_after,dptr_before,dptr_after,r0,r1,r2,r3,r4,r5,r6,r7,xdata_addr,xdata_value,trace_type,notes
+packet_bridge_default_5602_20260427T165429Z,90CYE03_19_DKS.PZU,0x5602,1,0x5602,LCALL,0x5A7F,,,,,,,,,,,,,,,call,
+packet_bridge_default_5602_20260427T165429Z,90CYE03_19_DKS.PZU,0x5602,1,0x5605,RET(stub),0x5A7F,,,,,,,,,,,,,,,ret,
+packet_bridge_default_5602_20260427T165429Z,90CYE03_19_DKS.PZU,0x5602,1,0x5602,LCALL,0x5A7F,0x00,0x00,0x0000,0x0000,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,,,instruction,
+packet_bridge_default_5602_20260427T165429Z,90CYE03_19_DKS.PZU,0x5602,2,0x5605,MOV,"A,R1",0x00,0x00,0x0000,0x0000,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,,,instruction,
+packet_bridge_default_5602_20260427T165429Z,90CYE03_19_DKS.PZU,0x5602,3,0x5606,MOVX,"@DPTR,A",0x00,0x00,0x0000,0x0000,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,,,instruction,watchpoint_hit=False;prev=None
+packet_bridge_default_5602_20260427T165429Z,90CYE03_19_DKS.PZU,0x5602,3,0x5606,MOVX,"@DPTR,A",,,,,,,,,,,,,0x0000,0x00,xdata_write,watchpoint_hit=False;prev=None
+packet_bridge_default_5602_20260427T165429Z,90CYE03_19_DKS.PZU,0x5602,4,0x5607,0x09,,,,,,,,,,,,,,,,unsupported_opcode,unsupported_opcode 0x09 at 0x5607

--- a/docs/emulator/trace_packet_bridge_default_5602_20260427T165433Z.csv
+++ b/docs/emulator/trace_packet_bridge_default_5602_20260427T165433Z.csv
@@ -1,0 +1,8 @@
+run_id,firmware_file,function_addr,step,pc,op,args,acc_before,acc_after,dptr_before,dptr_after,r0,r1,r2,r3,r4,r5,r6,r7,xdata_addr,xdata_value,trace_type,notes
+packet_bridge_default_5602_20260427T165433Z,90CYE03_19_DKS.PZU,0x5602,1,0x5602,LCALL,0x5A7F,,,,,,,,,,,,,,,call,
+packet_bridge_default_5602_20260427T165433Z,90CYE03_19_DKS.PZU,0x5602,1,0x5605,RET(stub),0x5A7F,,,,,,,,,,,,,,,ret,
+packet_bridge_default_5602_20260427T165433Z,90CYE03_19_DKS.PZU,0x5602,1,0x5602,LCALL,0x5A7F,0x00,0x00,0x0000,0x0000,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,,,instruction,
+packet_bridge_default_5602_20260427T165433Z,90CYE03_19_DKS.PZU,0x5602,2,0x5605,MOV,"A,R1",0x00,0x00,0x0000,0x0000,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,,,instruction,
+packet_bridge_default_5602_20260427T165433Z,90CYE03_19_DKS.PZU,0x5602,3,0x5606,MOVX,"@DPTR,A",0x00,0x00,0x0000,0x0000,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,,,instruction,watchpoint_hit=False;prev=None
+packet_bridge_default_5602_20260427T165433Z,90CYE03_19_DKS.PZU,0x5602,3,0x5606,MOVX,"@DPTR,A",,,,,,,,,,,,,0x0000,0x00,xdata_write,watchpoint_hit=False;prev=None
+packet_bridge_default_5602_20260427T165433Z,90CYE03_19_DKS.PZU,0x5602,4,0x5607,0x09,,,,,,,,,,,,,,,,unsupported_opcode,unsupported_opcode 0x09 at 0x5607

--- a/docs/emulator/trace_packet_bridge_default_5A7F_20260427T165429Z.csv
+++ b/docs/emulator/trace_packet_bridge_default_5A7F_20260427T165429Z.csv
@@ -1,0 +1,2 @@
+run_id,firmware_file,function_addr,step,pc,op,args,acc_before,acc_after,dptr_before,dptr_after,r0,r1,r2,r3,r4,r5,r6,r7,xdata_addr,xdata_value,trace_type,notes
+packet_bridge_default_5A7F_20260427T165429Z,90CYE03_19_DKS.PZU,0x5A7F,1,0x5A7F,0x25,,,,,,,,,,,,,,,,unsupported_opcode,unsupported_opcode 0x25 at 0x5A7F

--- a/docs/emulator/trace_packet_bridge_default_5A7F_20260427T165433Z.csv
+++ b/docs/emulator/trace_packet_bridge_default_5A7F_20260427T165433Z.csv
@@ -1,0 +1,2 @@
+run_id,firmware_file,function_addr,step,pc,op,args,acc_before,acc_after,dptr_before,dptr_after,r0,r1,r2,r3,r4,r5,r6,r7,xdata_addr,xdata_value,trace_type,notes
+packet_bridge_default_5A7F_20260427T165433Z,90CYE03_19_DKS.PZU,0x5A7F,1,0x5A7F,0x25,,,,,,,,,,,,,,,,unsupported_opcode,unsupported_opcode 0x25 at 0x5A7F

--- a/docs/emulator/unsupported_opcode_report.csv
+++ b/docs/emulator/unsupported_opcode_report.csv
@@ -1,0 +1,4 @@
+opcode,pc,function_addr,count,first_seen_run,notes
+0x08,0x55CF,0x55AD,1,packet_bridge_default_55AD_20260427T165433Z,unsupported
+0x09,0x5607,0x5602,1,packet_bridge_default_5602_20260427T165433Z,unsupported
+0x25,0x5A7F,0x5A7F,1,packet_bridge_default_5A7F_20260427T165433Z,unsupported

--- a/docs/emulator/xdata_write_trace.csv
+++ b/docs/emulator/xdata_write_trace.csv
@@ -1,0 +1,2 @@
+run_id,scenario,firmware_file,function_addr,step,pc,xdata_addr,value,previous_value,watchpoint_hit,possible_role,notes
+packet_bridge_default_5602_20260427T165433Z,packet_bridge_default,90CYE03_19_DKS.PZU,0x5602,3,0x5606,0x0000,0x00,,False,unknown_record,emulation_observed

--- a/docs/script_scope_matrix.csv
+++ b/docs/script_scope_matrix.csv
@@ -49,3 +49,4 @@ scripts/project_guided_micro_decompiler.py,true,false,true,true,true,true,projec
 scripts/project_guided_micro_decompiler_pass2.py,false,false,true,true,true,true,Pass2 project-guided micro-decompile for follow-up targets in DKS/RTOS_service/shifted_DKS with conservative evidence gating.
 scripts/project_guided_micro_decompiler_pass3.py,false,false,true,true,true,true,Pass3 project-guided micro-decompile for unresolved caller envelopes/table origins plus UART/checksum/timer conservative searches.
 scripts/project_guided_final_static_boundary.py,false,false,true,true,true,true,Final boundary pass for 0x5A7F caller-block closure and explicit do-not-repeat evidence gates.
+scripts/firmware_execution_sandbox.py,false,false,false,true,true,true,Experimental deterministic function-level 8051-subset sandbox; logs unsupported opcodes and XDATA traces without claiming full emulation.

--- a/emulator/README.md
+++ b/emulator/README.md
@@ -1,0 +1,25 @@
+# Firmware execution sandbox (experimental MVP)
+
+## Purpose
+
+This sandbox is an **experimental, deterministic function-level trace harness** for firmware reverse engineering. It is focused on running constrained 8051-like function windows to observe:
+
+- register changes (ACC, DPTR, R0..R7);
+- call/return flow;
+- `MOVX`-driven XDATA reads/writes;
+- candidate packet/event record write patterns.
+
+Current focus area: packet/event bridge hypotheses around **0x5A7F** and its high-fan-in caller blocks.
+
+## What this is not
+
+This is **not** a full hardware emulator and does not claim full CPU/device accuracy.
+
+Limitations currently include:
+
+- no verified UART/SFR mapping yet;
+- no real RS-485 frame decoding yet;
+- no timer/interrupt accuracy yet;
+- no bench confirmation.
+
+All outputs should be interpreted as constrained emulation evidence and labeled conservatively (`emulation_observed`, `static_code`, `hypothesis`, `unsupported`).

--- a/emulator/cpu8051_subset.py
+++ b/emulator/cpu8051_subset.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable
+
+from emulator.pzu_memory import CodeImage
+from emulator.trace import TraceLog
+
+
+@dataclass
+class CPU8051State:
+    pc: int = 0
+    acc: int = 0
+    b: int = 0
+    dptr: int = 0
+    psw: int = 0
+    sp: int = 0x07
+    regs: list[int] = field(default_factory=lambda: [0] * 8)
+    xdata: dict[int, int] = field(default_factory=dict)
+    call_stack: list[int] = field(default_factory=list)
+    step_counter: int = 0
+
+
+class CPU8051Subset:
+    def __init__(
+        self,
+        code_image: CodeImage,
+        state: CPU8051State,
+        trace: TraceLog,
+        watchpoints: set[int] | None = None,
+        stub_calls: dict[int, Callable[[CPU8051State, TraceLog], None]] | None = None,
+        allow_skip_unsupported: bool = False,
+    ) -> None:
+        self.code = code_image
+        self.s = state
+        self.trace = trace
+        self.watchpoints = watchpoints or set()
+        self.stub_calls = stub_calls or {}
+        self.allow_skip_unsupported = allow_skip_unsupported
+
+    def fetch(self, addr: int) -> int:
+        return self.code.get_byte(addr)
+
+    def _rel(self, offset: int) -> int:
+        return offset - 256 if offset & 0x80 else offset
+
+    def _log_instr(self, op: str, args: str, pc: int, acc_before: int, dptr_before: int, notes: str = "") -> None:
+        self.trace.add(
+            {
+                "step": self.s.step_counter,
+                "pc": pc,
+                "op": op,
+                "args": args,
+                "acc_before": f"0x{acc_before:02X}",
+                "acc_after": f"0x{self.s.acc:02X}",
+                "dptr_before": dptr_before,
+                "dptr_after": self.s.dptr,
+                "r0": f"0x{self.s.regs[0]:02X}",
+                "r1": f"0x{self.s.regs[1]:02X}",
+                "r2": f"0x{self.s.regs[2]:02X}",
+                "r3": f"0x{self.s.regs[3]:02X}",
+                "r4": f"0x{self.s.regs[4]:02X}",
+                "r5": f"0x{self.s.regs[5]:02X}",
+                "r6": f"0x{self.s.regs[6]:02X}",
+                "r7": f"0x{self.s.regs[7]:02X}",
+                "trace_type": "instruction",
+                "notes": notes,
+            }
+        )
+
+    def step(self) -> tuple[bool, str | None]:
+        s = self.s
+        pc = s.pc
+        op = self.fetch(pc)
+        acc_before = s.acc
+        dptr_before = s.dptr
+
+        if op == 0x74:  # MOV A,#imm
+            imm = self.fetch(pc + 1)
+            s.acc = imm
+            s.pc += 2
+            self._log_instr("MOV", f"A,#0x{imm:02X}", pc, acc_before, dptr_before)
+            return True, None
+
+        if 0xE8 <= op <= 0xEF:  # MOV A,Rn
+            n = op - 0xE8
+            s.acc = s.regs[n]
+            s.pc += 1
+            self._log_instr("MOV", f"A,R{n}", pc, acc_before, dptr_before)
+            return True, None
+
+        if 0xF8 <= op <= 0xFF:  # MOV Rn,A
+            n = op - 0xF8
+            s.regs[n] = s.acc
+            s.pc += 1
+            self._log_instr("MOV", f"R{n},A", pc, acc_before, dptr_before)
+            return True, None
+
+        if 0x78 <= op <= 0x7F:  # MOV Rn,#imm
+            n = op - 0x78
+            imm = self.fetch(pc + 1)
+            s.regs[n] = imm
+            s.pc += 2
+            self._log_instr("MOV", f"R{n},#0x{imm:02X}", pc, acc_before, dptr_before)
+            return True, None
+
+        if op == 0x90:
+            hi = self.fetch(pc + 1)
+            lo = self.fetch(pc + 2)
+            s.dptr = ((hi << 8) | lo) & 0xFFFF
+            s.pc += 3
+            self._log_instr("MOV", f"DPTR,#0x{s.dptr:04X}", pc, acc_before, dptr_before)
+            return True, None
+
+        if op == 0xF0:
+            addr = s.dptr
+            prev = s.xdata.get(addr)
+            s.xdata[addr] = s.acc
+            s.pc += 1
+            note = f"watchpoint_hit={addr in self.watchpoints};prev={prev}"
+            self._log_instr("MOVX", "@DPTR,A", pc, acc_before, dptr_before, notes=note)
+            self.trace.add({"step": s.step_counter, "pc": pc, "op": "MOVX", "args": "@DPTR,A", "xdata_addr": addr, "xdata_value": f"0x{s.acc:02X}", "trace_type": "xdata_write", "notes": note})
+            return True, None
+
+        if op == 0xE0:
+            addr = s.dptr
+            s.acc = s.xdata.get(addr, 0)
+            s.pc += 1
+            note = f"watchpoint_hit={addr in self.watchpoints}"
+            self._log_instr("MOVX", "A,@DPTR", pc, acc_before, dptr_before, notes=note)
+            self.trace.add({"step": s.step_counter, "pc": pc, "op": "MOVX", "args": "A,@DPTR", "xdata_addr": addr, "xdata_value": f"0x{s.acc:02X}", "trace_type": "xdata_read", "notes": note})
+            return True, None
+
+        if op == 0xA3:
+            s.dptr = (s.dptr + 1) & 0xFFFF
+            s.pc += 1
+            self._log_instr("INC", "DPTR", pc, acc_before, dptr_before)
+            return True, None
+
+        if op in (0x54, 0x44, 0x64, 0x24):
+            imm = self.fetch(pc + 1)
+            if op == 0x54:
+                s.acc = s.acc & imm
+                opname = "ANL"
+            elif op == 0x44:
+                s.acc = s.acc | imm
+                opname = "ORL"
+            elif op == 0x64:
+                s.acc = s.acc ^ imm
+                opname = "XRL"
+            else:
+                s.acc = (s.acc + imm) & 0xFF
+                opname = "ADD"
+            s.pc += 2
+            self._log_instr(opname, f"A,#0x{imm:02X}", pc, acc_before, dptr_before)
+            return True, None
+
+        if op == 0xE4:
+            s.acc = 0
+            s.pc += 1
+            self._log_instr("CLR", "A", pc, acc_before, dptr_before)
+            return True, None
+
+        if op == 0xB4:  # CJNE A,#imm,rel
+            imm = self.fetch(pc + 1)
+            rel = self.fetch(pc + 2)
+            if s.acc != imm:
+                s.pc = (pc + 3 + self._rel(rel)) & 0xFFFF
+            else:
+                s.pc = (pc + 3) & 0xFFFF
+            self._log_instr("CJNE", f"A,#0x{imm:02X},{self._rel(rel)}", pc, acc_before, dptr_before)
+            return True, None
+
+        if op in (0x60, 0x70, 0x80):
+            rel = self.fetch(pc + 1)
+            do_jump = (op == 0x80) or (op == 0x60 and s.acc == 0) or (op == 0x70 and s.acc != 0)
+            s.pc = (pc + 2 + self._rel(rel)) & 0xFFFF if do_jump else (pc + 2) & 0xFFFF
+            opname = "SJMP" if op == 0x80 else ("JZ" if op == 0x60 else "JNZ")
+            self._log_instr(opname, str(self._rel(rel)), pc, acc_before, dptr_before)
+            return True, None
+
+        if op == 0x12:  # LCALL
+            hi = self.fetch(pc + 1)
+            lo = self.fetch(pc + 2)
+            target = ((hi << 8) | lo) & 0xFFFF
+            ret = (pc + 3) & 0xFFFF
+            self.trace.add({"step": s.step_counter, "pc": pc, "op": "LCALL", "args": f"0x{target:04X}", "trace_type": "call"})
+            if target in self.stub_calls:
+                self.stub_calls[target](s, self.trace)
+                s.pc = ret
+                self.trace.add({"step": s.step_counter, "pc": s.pc, "op": "RET(stub)", "args": f"0x{target:04X}", "trace_type": "ret"})
+            else:
+                s.call_stack.append(ret)
+                s.pc = target
+            self._log_instr("LCALL", f"0x{target:04X}", pc, acc_before, dptr_before)
+            return True, None
+
+        if op == 0x02:  # LJMP
+            hi = self.fetch(pc + 1)
+            lo = self.fetch(pc + 2)
+            target = ((hi << 8) | lo) & 0xFFFF
+            s.pc = target
+            self._log_instr("LJMP", f"0x{target:04X}", pc, acc_before, dptr_before)
+            return True, None
+
+        if op == 0x22:
+            self.trace.add({"step": s.step_counter, "pc": pc, "op": "RET", "trace_type": "ret"})
+            if s.call_stack:
+                s.pc = s.call_stack.pop()
+                self._log_instr("RET", "", pc, acc_before, dptr_before)
+                return True, None
+            s.pc = (pc + 1) & 0xFFFF
+            self._log_instr("RET", "", pc, acc_before, dptr_before)
+            return False, "ret_from_entry"
+
+        msg = f"unsupported_opcode 0x{op:02X} at 0x{pc:04X}"
+        self.trace.add({"step": s.step_counter, "pc": pc, "op": f"0x{op:02X}", "trace_type": "unsupported_opcode", "notes": msg})
+        if self.allow_skip_unsupported:
+            s.pc = (pc + 1) & 0xFFFF
+            self._log_instr("UNSUPPORTED_SKIP", f"0x{op:02X}", pc, acc_before, dptr_before, notes=msg)
+            return True, None
+        return False, msg

--- a/emulator/function_harness.py
+++ b/emulator/function_harness.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from emulator.cpu8051_subset import CPU8051State, CPU8051Subset
+from emulator.pzu_memory import CodeImage
+from emulator.trace import TraceContext, TraceLog
+
+
+@dataclass
+class FunctionRunResult:
+    run_id: str
+    firmware_file: str
+    function_addr: int
+    steps: int
+    stop_reason: str
+    calls_seen: int
+    returns_seen: int
+    xdata_reads: int
+    xdata_writes: int
+    unsupported_ops: int
+    trace: TraceLog
+
+
+class FunctionHarness:
+    def __init__(self, code: CodeImage, watchpoints: list[int] | None = None) -> None:
+        self.code = code
+        self.watchpoints = set(watchpoints or [])
+
+    @staticmethod
+    def default_stubs(enable: bool = True):
+        if not enable:
+            return {}
+
+        def stub_597F(s: CPU8051State, _t: TraceLog) -> None:
+            s.acc &= 0x07
+
+        def stub_7922(s: CPU8051State, _t: TraceLog) -> None:
+            s.regs[0] = s.xdata.get(s.dptr, 0)
+            s.regs[1] = s.xdata.get((s.dptr + 1) & 0xFFFF, 0)
+
+        def stub_5A7F(_s: CPU8051State, _t: TraceLog) -> None:
+            return
+
+        return {0x597F: stub_597F, 0x7922: stub_7922, 0x5A7F: stub_5A7F}
+
+    def run_function(
+        self,
+        run_id: str,
+        function_addr: int,
+        max_steps: int = 500,
+        max_calls: int = 64,
+        init_regs: dict[str, int] | None = None,
+        init_xdata: dict[int, int] | None = None,
+        allow_skip_unsupported: bool = False,
+        use_stubs: bool = True,
+    ) -> FunctionRunResult:
+        state = CPU8051State(pc=function_addr)
+        if init_regs:
+            for k, v in init_regs.items():
+                vv = v & 0xFF
+                if k == "A":
+                    state.acc = vv
+                elif k == "DPTR":
+                    state.dptr = v & 0xFFFF
+                elif k.startswith("R") and k[1:].isdigit():
+                    idx = int(k[1:])
+                    if 0 <= idx <= 7:
+                        state.regs[idx] = vv
+        if init_xdata:
+            state.xdata.update({k & 0xFFFF: v & 0xFF for k, v in init_xdata.items()})
+
+        trace = TraceLog(TraceContext(run_id=run_id, firmware_file=self.code.firmware_file, function_addr=function_addr))
+        cpu = CPU8051Subset(
+            code_image=self.code,
+            state=state,
+            trace=trace,
+            watchpoints=self.watchpoints,
+            stub_calls=self.default_stubs(enable=use_stubs),
+            allow_skip_unsupported=allow_skip_unsupported,
+        )
+
+        stop_reason = "max_steps"
+        for _ in range(max_steps):
+            state.step_counter += 1
+            if len(state.call_stack) > max_calls:
+                stop_reason = "max_calls"
+                break
+            cont, reason = cpu.step()
+            if not cont:
+                stop_reason = reason or "stop"
+                break
+
+        rows = trace.rows
+        return FunctionRunResult(
+            run_id=run_id,
+            firmware_file=self.code.firmware_file,
+            function_addr=function_addr,
+            steps=state.step_counter,
+            stop_reason=stop_reason,
+            calls_seen=sum(1 for r in rows if r["trace_type"] == "call"),
+            returns_seen=sum(1 for r in rows if r["trace_type"] == "ret"),
+            xdata_reads=sum(1 for r in rows if r["trace_type"] == "xdata_read"),
+            xdata_writes=sum(1 for r in rows if r["trace_type"] == "xdata_write"),
+            unsupported_ops=sum(1 for r in rows if r["trace_type"] == "unsupported_opcode"),
+            trace=trace,
+        )

--- a/emulator/pzu_memory.py
+++ b/emulator/pzu_memory.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from dataclasses import dataclass
+import csv
+from pathlib import Path
+
+from scripts.pzu_common import load_intel_hex
+
+
+@dataclass
+class CodeImage:
+    firmware_file: str
+    source: str
+    bytes_by_addr: dict[int, int]
+    reliable_bytes: bool = True
+    notes: str = ""
+
+    def get_byte(self, addr: int) -> int:
+        return self.bytes_by_addr.get(addr & 0xFFFF, 0xFF)
+
+    def get_window(self, start: int, size: int) -> list[int]:
+        return [self.get_byte(start + i) for i in range(size)]
+
+
+def load_code_image(path: Path | str) -> CodeImage:
+    p = Path(path)
+    if p.suffix.upper() == ".PZU":
+        mem, _stats = load_intel_hex(p)
+        return CodeImage(
+            firmware_file=p.name,
+            source="pzu_intel_hex",
+            bytes_by_addr={i: b for i, b in enumerate(mem)},
+            reliable_bytes=True,
+        )
+    if p.suffix.lower() == ".csv":
+        return load_from_disassembly_index(p, firmware_file="")
+    raise ValueError(f"Unsupported code image source: {p}")
+
+
+def load_from_disassembly_index(csv_path: Path | str, firmware_file: str) -> CodeImage:
+    path = Path(csv_path)
+    bytes_by_addr: dict[int, int] = {}
+    with path.open("r", encoding="utf-8", newline="") as fh:
+        reader = csv.DictReader(fh)
+        for row in reader:
+            row_file = (row.get("file") or "").strip()
+            if firmware_file and row_file != firmware_file:
+                continue
+            code_addr = row.get("code_addr", "")
+            op_hex = (row.get("opcode_hex") or "").strip()
+            if not code_addr or not op_hex:
+                continue
+            try:
+                base = int(code_addr, 16)
+            except ValueError:
+                continue
+            parts = [p for p in op_hex.split() if p]
+            for i, part in enumerate(parts):
+                try:
+                    bytes_by_addr[(base + i) & 0xFFFF] = int(part, 16)
+                except ValueError:
+                    continue
+
+    return CodeImage(
+        firmware_file=firmware_file or path.name,
+        source="disassembly_index",
+        bytes_by_addr=bytes_by_addr,
+        reliable_bytes=False,
+        notes=(
+            "Loaded from disassembly CSV opcode_hex windows. Useful for constrained tracing when full byte-extraction "
+            "is unavailable; coverage and ordering may be incomplete."
+        ),
+    )

--- a/emulator/scenarios.py
+++ b/emulator/scenarios.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from emulator.watchpoints import default_dks_watchpoints, default_rtos_service_watchpoints, default_shifted_dks_watchpoints, expand_range
+
+
+@dataclass(frozen=True)
+class Scenario:
+    name: str
+    firmware_file: str
+    functions: list[int]
+    seed_xdata: dict[int, int]
+    watchpoints: list[int]
+    purpose: str
+
+
+def _seed_addrs(addrs: list[int], base: int = 1) -> dict[int, int]:
+    return {a: (base + i) & 0xFF for i, a in enumerate(addrs)}
+
+
+SCENARIOS = {
+    "packet_bridge_default": Scenario(
+        name="packet_bridge_default",
+        firmware_file="90CYE03_19_DKS.PZU",
+        functions=[0x55AD, 0x5602, 0x5A7F],
+        seed_xdata=_seed_addrs([0x30BC, 0x30E1, 0x7160], base=0x10),
+        watchpoints=default_dks_watchpoints(),
+        purpose="Observe pointer/index staging and MOVX writes around packet/event bridge hypotheses.",
+    ),
+    "zone_fire_candidate": Scenario(
+        name="zone_fire_candidate",
+        firmware_file="90CYE03_19_DKS.PZU",
+        functions=[0x497A, 0x737C],
+        seed_xdata=_seed_addrs(expand_range("0x3010..0x301B") + [0x31BF] + expand_range("0x36D3..0x36FD"), base=0x20),
+        watchpoints=default_dks_watchpoints(),
+        purpose="Observe state/event record write patterns.",
+    ),
+    "aerosol_start_candidate": Scenario(
+        name="aerosol_start_candidate",
+        firmware_file="90CYE03_19_DKS.PZU",
+        functions=[0x84A6, 0x6833, 0x7DC2],
+        seed_xdata=_seed_addrs([0x30E7, 0x30E9, 0x3640, 0x364B], base=0x30),
+        watchpoints=default_dks_watchpoints(),
+        purpose="Observe output-start marker behavior and downstream writes.",
+    ),
+    "shifted_valve_status_candidate": Scenario(
+        name="shifted_valve_status_candidate",
+        firmware_file="90CYE02_27 DKS.PZU",
+        functions=[0x673C, 0x613C, 0x7773],
+        seed_xdata=_seed_addrs([0x3104, 0x3108, 0x31DD, 0x32B2, 0x32B3], base=0x40),
+        watchpoints=default_shifted_dks_watchpoints(),
+        purpose="Observe status-table writes in shifted_DKS branch.",
+    ),
+    "rtos_service_candidate": Scenario(
+        name="rtos_service_candidate",
+        firmware_file="ppkp2001 90cye01.PZU",
+        functions=[0x920C, 0x4374, 0x9255, 0x9275, 0x758B],
+        seed_xdata=_seed_addrs([0x30BC, 0x30E1, 0x31BF, 0x3640, 0x364B], base=0x50),
+        watchpoints=default_rtos_service_watchpoints(),
+        purpose="Observe service-table reads/writes from RTOS_service candidates.",
+    ),
+}
+
+
+def list_scenarios() -> list[Scenario]:
+    return list(SCENARIOS.values())
+
+
+def get_scenario(name: str) -> Scenario:
+    return SCENARIOS[name]

--- a/emulator/trace.py
+++ b/emulator/trace.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from pathlib import Path
+
+TRACE_COLUMNS = [
+    "run_id",
+    "firmware_file",
+    "function_addr",
+    "step",
+    "pc",
+    "op",
+    "args",
+    "acc_before",
+    "acc_after",
+    "dptr_before",
+    "dptr_after",
+    "r0",
+    "r1",
+    "r2",
+    "r3",
+    "r4",
+    "r5",
+    "r6",
+    "r7",
+    "xdata_addr",
+    "xdata_value",
+    "trace_type",
+    "notes",
+]
+
+
+@dataclass
+class TraceContext:
+    run_id: str
+    firmware_file: str
+    function_addr: int
+
+
+class TraceLog:
+    def __init__(self, ctx: TraceContext) -> None:
+        self.ctx = ctx
+        self.rows: list[dict[str, str]] = []
+
+    def add(self, row: dict[str, object]) -> None:
+        base = {
+            "run_id": self.ctx.run_id,
+            "firmware_file": self.ctx.firmware_file,
+            "function_addr": f"0x{self.ctx.function_addr:04X}",
+            "xdata_addr": "",
+            "xdata_value": "",
+            "notes": "",
+            "args": "",
+        }
+        for k, v in row.items():
+            if v is None:
+                continue
+            base[k] = f"0x{v:04X}" if k in {"pc", "dptr_before", "dptr_after", "xdata_addr"} and isinstance(v, int) else str(v)
+        self.rows.append({k: str(base.get(k, "")) for k in TRACE_COLUMNS})
+
+    def write_csv(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=TRACE_COLUMNS)
+            writer.writeheader()
+            writer.writerows(self.rows)

--- a/emulator/watchpoints.py
+++ b/emulator/watchpoints.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+
+def expand_range(spec: str) -> list[int]:
+    left, right = spec.split("..")
+    start = int(left, 16)
+    end = int(right, 16)
+    return list(range(start, end + 1))
+
+
+def _sorted_unique(values: list[int]) -> list[int]:
+    return sorted(set(v & 0xFFFF for v in values))
+
+
+def default_dks_watchpoints() -> list[int]:
+    values = [0x30BC, 0x30E1, 0x7160, 0x30E7, 0x30E9, 0x31BF, 0x3640, 0x364B, 0x3104, 0x3108, 0x31DD, 0x32B2, 0x32B3]
+    values += expand_range("0x3010..0x301B")
+    values += expand_range("0x36D3..0x36FD")
+    return _sorted_unique(values)
+
+
+def default_shifted_dks_watchpoints() -> list[int]:
+    return _sorted_unique([0x3104, 0x3108, 0x31DD, 0x32B2, 0x32B3])
+
+
+def default_rtos_service_watchpoints() -> list[int]:
+    return _sorted_unique([0x30BC, 0x30E1, 0x31BF, 0x3640, 0x364B])

--- a/scripts/firmware_execution_sandbox.py
+++ b/scripts/firmware_execution_sandbox.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import csv
+from collections import Counter
+from datetime import datetime
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from emulator.function_harness import FunctionHarness, FunctionRunResult
+from emulator.pzu_memory import load_code_image
+from emulator.scenarios import get_scenario, list_scenarios
+OUT = ROOT / "docs" / "emulator"
+TRACE_CSV = OUT / "xdata_write_trace.csv"
+SUMMARY_CSV = OUT / "function_trace_summary.csv"
+UNSUPPORTED_CSV = OUT / "unsupported_opcode_report.csv"
+CANDIDATES_CSV = OUT / "candidate_packet_records.csv"
+REPORT_MD = OUT / "firmware_execution_sandbox_report.md"
+
+
+def _run_id(prefix: str) -> str:
+    return f"{prefix}_{datetime.utcnow().strftime('%Y%m%dT%H%M%SZ')}"
+
+
+def _write_summary(rows: list[dict[str, str]]) -> None:
+    OUT.mkdir(parents=True, exist_ok=True)
+    cols = ["run_id", "scenario", "firmware_file", "function_addr", "steps", "stop_reason", "calls_seen", "returns_seen", "xdata_reads", "xdata_writes", "unsupported_ops", "confidence", "notes"]
+    with SUMMARY_CSV.open("w", encoding="utf-8", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=cols)
+        w.writeheader()
+        w.writerows(rows)
+
+
+def _collect_xdata_writes(run: FunctionRunResult, scenario_name: str) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for r in run.trace.rows:
+        if r["trace_type"] != "xdata_write":
+            continue
+        addr = int(r["xdata_addr"], 16) if r["xdata_addr"] else 0
+        note = r.get("notes", "")
+        rows.append(
+            {
+                "run_id": run.run_id,
+                "scenario": scenario_name,
+                "firmware_file": run.firmware_file,
+                "function_addr": f"0x{run.function_addr:04X}",
+                "step": r["step"],
+                "pc": r["pc"],
+                "xdata_addr": f"0x{addr:04X}",
+                "value": r["xdata_value"],
+                "previous_value": "",
+                "watchpoint_hit": "True" if "watchpoint_hit=True" in note else "False",
+                "possible_role": "pointer_staging_candidate" if addr in {0x30BC, 0x30E1, 0x7160} else "unknown_record",
+                "notes": "emulation_observed",
+            }
+        )
+    return rows
+
+
+def _write_xdata(rows: list[dict[str, str]]) -> None:
+    cols = ["run_id", "scenario", "firmware_file", "function_addr", "step", "pc", "xdata_addr", "value", "previous_value", "watchpoint_hit", "possible_role", "notes"]
+    with TRACE_CSV.open("w", encoding="utf-8", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=cols)
+        w.writeheader()
+        w.writerows(rows)
+
+
+def _write_unsupported(all_runs: list[FunctionRunResult]) -> None:
+    counter: Counter[tuple[str, str, str]] = Counter()
+    first_seen: dict[tuple[str, str, str], str] = {}
+    for run in all_runs:
+        for r in run.trace.rows:
+            if r["trace_type"] != "unsupported_opcode":
+                continue
+            key = (r["op"], r["pc"], f"0x{run.function_addr:04X}")
+            counter[key] += 1
+            first_seen.setdefault(key, run.run_id)
+    cols = ["opcode", "pc", "function_addr", "count", "first_seen_run", "notes"]
+    with UNSUPPORTED_CSV.open("w", encoding="utf-8", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=cols)
+        w.writeheader()
+        for (opcode, pc, faddr), count in sorted(counter.items()):
+            w.writerow({"opcode": opcode, "pc": pc, "function_addr": faddr, "count": count, "first_seen_run": first_seen[(opcode, pc, faddr)], "notes": "unsupported"})
+
+
+def _write_candidates(xdata_rows: list[dict[str, str]]) -> None:
+    cols = ["run_id", "scenario", "function_addr", "record_base", "record_bytes", "source_xdata_addrs", "possible_role", "confidence", "evidence_level", "notes"]
+    grouped: dict[tuple[str, str, str], list[int]] = {}
+    for r in xdata_rows:
+        key = (r["run_id"], r["scenario"], r["function_addr"])
+        grouped.setdefault(key, []).append(int(r["xdata_addr"], 16))
+
+    rows: list[dict[str, str]] = []
+    for (run_id, scenario, faddr), addrs in grouped.items():
+        addrs = sorted(set(addrs))
+        if not addrs:
+            continue
+        base = addrs[0]
+        contiguous = [a for a in addrs if a - base < 16]
+        role = "pointer_staging_candidate" if base in {0x30BC, 0x30E1, 0x7160} else "unknown_record"
+        rows.append(
+            {
+                "run_id": run_id,
+                "scenario": scenario,
+                "function_addr": faddr,
+                "record_base": f"0x{base:04X}",
+                "record_bytes": str(len(contiguous)),
+                "source_xdata_addrs": ";".join(f"0x{a:04X}" for a in contiguous),
+                "possible_role": role,
+                "confidence": "low",
+                "evidence_level": "emulation_observed",
+                "notes": "Grouped contiguous observed XDATA writes only; format not decoded.",
+            }
+        )
+
+    with CANDIDATES_CSV.open("w", encoding="utf-8", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=cols)
+        w.writeheader()
+        w.writerows(rows)
+
+
+def _write_report(source_note: str, runs: list[FunctionRunResult], scenario_name: str | None) -> None:
+    unsupported = sum(r.unsupported_ops for r in runs)
+    writes = sum(r.xdata_writes for r in runs)
+    funcs = ", ".join(f"0x{r.function_addr:04X}" for r in runs)
+    scenario_line = scenario_name if scenario_name else "ad-hoc function run"
+    REPORT_MD.write_text(
+        "\n".join(
+            [
+                "# Firmware execution sandbox report",
+                "",
+                "## Scope",
+                "Experimental function-level 8051-subset tracing for selected targets. Evidence level: emulation_observed.",
+                "",
+                "## CPU subset status",
+                "Implemented subset includes MOV/MOVX/DPTR ops, simple ALU immediates, limited branches, LCALL/LJMP/RET.",
+                "Unsupported opcodes are logged and never silently ignored.",
+                "",
+                "## Loaded firmware/artifact source",
+                source_note,
+                "",
+                "## Target functions tested",
+                f"Scenario: {scenario_line}",
+                f"Functions: {funcs}",
+                "",
+                "## Unsupported opcodes encountered",
+                str(unsupported),
+                "",
+                "## XDATA writes observed",
+                str(writes),
+                "",
+                "## Candidate packet/event records",
+                "See docs/emulator/candidate_packet_records.csv (contiguous observed writes only; no packet format invention).",
+                "",
+                "No real RS-485 command is confirmed unless UART/SBUF writes or decoded packet bytes are observed.",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def run_scenario(name: str, max_steps: int) -> None:
+    scenario = get_scenario(name)
+    img = load_code_image(ROOT / scenario.firmware_file)
+    harness = FunctionHarness(img, watchpoints=scenario.watchpoints)
+
+    all_runs: list[FunctionRunResult] = []
+    summary_rows: list[dict[str, str]] = []
+    xdata_rows: list[dict[str, str]] = []
+
+    for faddr in scenario.functions:
+        rid = _run_id(f"{name}_{faddr:04X}")
+        run = harness.run_function(rid, faddr, max_steps=max_steps, init_xdata=scenario.seed_xdata)
+        all_runs.append(run)
+        trace_path = OUT / f"trace_{rid}.csv"
+        run.trace.write_csv(trace_path)
+        summary_rows.append(
+            {
+                "run_id": rid,
+                "scenario": name,
+                "firmware_file": scenario.firmware_file,
+                "function_addr": f"0x{faddr:04X}",
+                "steps": str(run.steps),
+                "stop_reason": run.stop_reason,
+                "calls_seen": str(run.calls_seen),
+                "returns_seen": str(run.returns_seen),
+                "xdata_reads": str(run.xdata_reads),
+                "xdata_writes": str(run.xdata_writes),
+                "unsupported_ops": str(run.unsupported_ops),
+                "confidence": "low",
+                "notes": "emulation_observed",
+            }
+        )
+        xdata_rows.extend(_collect_xdata_writes(run, name))
+
+    _write_summary(summary_rows)
+    _write_xdata(xdata_rows)
+    _write_unsupported(all_runs)
+    _write_candidates(xdata_rows)
+    _write_report(f"{img.firmware_file} via {img.source}", all_runs, scenario_name=name)
+
+
+def run_single_function(firmware: str, addr: int, max_steps: int) -> None:
+    img = load_code_image(ROOT / firmware)
+    harness = FunctionHarness(img)
+    rid = _run_id(f"single_{addr:04X}")
+    run = harness.run_function(rid, addr, max_steps=max_steps)
+    OUT.mkdir(parents=True, exist_ok=True)
+    run.trace.write_csv(OUT / f"trace_{rid}.csv")
+    _write_summary(
+        [
+            {
+                "run_id": rid,
+                "scenario": "single",
+                "firmware_file": firmware,
+                "function_addr": f"0x{addr:04X}",
+                "steps": str(run.steps),
+                "stop_reason": run.stop_reason,
+                "calls_seen": str(run.calls_seen),
+                "returns_seen": str(run.returns_seen),
+                "xdata_reads": str(run.xdata_reads),
+                "xdata_writes": str(run.xdata_writes),
+                "unsupported_ops": str(run.unsupported_ops),
+                "confidence": "low",
+                "notes": "emulation_observed",
+            }
+        ]
+    )
+    _write_xdata(_collect_xdata_writes(run, "single"))
+    _write_unsupported([run])
+    _write_candidates(_collect_xdata_writes(run, "single"))
+    _write_report(f"{img.firmware_file} via {img.source}", [run], scenario_name=None)
+
+
+def export_trace() -> None:
+    print(f"Summary: {SUMMARY_CSV}")
+    print(f"XDATA writes: {TRACE_CSV}")
+    print(f"Unsupported: {UNSUPPORTED_CSV}")
+    print(f"Candidates: {CANDIDATES_CSV}")
+    print(f"Report: {REPORT_MD}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Experimental firmware execution sandbox for constrained 8051-like tracing.")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("list-scenarios", help="List built-in scenario names.")
+
+    p_run = sub.add_parser("run-scenario", help="Run predefined scenario.")
+    p_run.add_argument("name")
+    p_run.add_argument("--max-steps", type=int, default=500)
+
+    p_func = sub.add_parser("run-function", help="Run single function entrypoint.")
+    p_func.add_argument("--firmware", required=True)
+    p_func.add_argument("--addr", required=True)
+    p_func.add_argument("--max-steps", type=int, default=500)
+
+    sub.add_parser("export-trace", help="Show output file locations.")
+    args = parser.parse_args()
+
+    if args.cmd == "list-scenarios":
+        for s in list_scenarios():
+            print(f"{s.name}: firmware={s.firmware_file}, functions={[hex(f) for f in s.functions]}")
+        return 0
+    if args.cmd == "run-scenario":
+        run_scenario(args.name, max_steps=args.max_steps)
+        print(f"Scenario '{args.name}' complete. Outputs in {OUT}")
+        return 0
+    if args.cmd == "run-function":
+        run_single_function(args.firmware, int(args.addr, 16), max_steps=args.max_steps)
+        print(f"Function run complete. Outputs in {OUT}")
+        return 0
+    if args.cmd == "export-trace":
+        export_trace()
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_analysis_smoke_test.py
+++ b/scripts/run_analysis_smoke_test.py
@@ -41,9 +41,36 @@ def main() -> int:
         SmokeCommand(
             script="py_compile",
             scope="utility",
-            command=[sys.executable, "-m", "py_compile", "scripts/*.py"],
+            command=[sys.executable, "-m", "py_compile", "scripts/*.py", "emulator/*.py"],
             output_files=[],
             notes="syntax compile check for all scripts",
+        ),
+        SmokeCommand(
+            "firmware_execution_sandbox.py:list-scenarios",
+            "experimental_emulator",
+            [sys.executable, "scripts/firmware_execution_sandbox.py", "list-scenarios"],
+            [],
+            "lightweight CLI probe for experimental firmware execution sandbox",
+        ),
+        SmokeCommand(
+            "firmware_execution_sandbox.py:packet_bridge_default",
+            "experimental_emulator",
+            [
+                sys.executable,
+                "scripts/firmware_execution_sandbox.py",
+                "run-scenario",
+                "packet_bridge_default",
+                "--max-steps",
+                "100",
+            ],
+            [
+                "docs/emulator/firmware_execution_sandbox_report.md",
+                "docs/emulator/function_trace_summary.csv",
+                "docs/emulator/xdata_write_trace.csv",
+                "docs/emulator/unsupported_opcode_report.csv",
+                "docs/emulator/candidate_packet_records.csv",
+            ],
+            "smoke scenario; success means deterministic run and clean unsupported-opcode reporting without crash",
         ),
         SmokeCommand("validate_pzu.py", "all_firmwares", [sys.executable, "scripts/validate_pzu.py"], [], "validation only"),
         SmokeCommand(


### PR DESCRIPTION
### Motivation

- Provide a deterministic, function-level execution sandbox to cross the static-analysis boundary and observe DPTR/ACC/R0/R1 staging, `MOVX` XDATA reads/writes, and call/return flow around packet/event bridge candidates (notably the 0x5A7F area). 
- Enable constrained dynamic tracing for hypothesis generation without claiming full CPU/hardware accuracy or decoding RS-485 unless bytes are directly observed.
- Integrate a lightweight, reproducible smoke-check into existing analysis orchestration so tracing can run in CI-like checks without hardware.

### Description

- Added an `emulator/` package implementing a minimal 8051-like tracer: `pzu_memory.py` (loads `.PZU` Intel HEX or disassembly CSV windows), `cpu8051_subset.py` (execution state + subset interpreter), `trace.py` (CSV-oriented trace model), `watchpoints.py` (default watchpoint sets and range expansion), `function_harness.py` (controlled function runner with optional stubs for `0x5A7F`, `0x597F`, `0x7922`), and `scenarios.py` (predefined scenarios including `packet_bridge_default`).
- Added CLI `scripts/firmware_execution_sandbox.py` with `list-scenarios`, `run-scenario <name>`, `run-function --firmware <file> --addr <addr>`, and `export-trace`, which writes traces and summary artifacts to `docs/emulator/`.
- Emit conservative, evidence-labeled outputs and CSVs: `function_trace_summary.csv`, `xdata_write_trace.csv`, `unsupported_opcode_report.csv`, `candidate_packet_records.csv`, per-run `trace_*.csv`, and `firmware_execution_sandbox_report.md`; and include explicit limitations in `docs/emulator/emulation_limitations.md` and `emulator/README.md`.
- Do not modify `.PZU` files; updated `README.md` and `docs/script_scope_matrix.csv` to document the sandbox and added lightweight smoke entries in `scripts/run_analysis_smoke_test.py` including `py_compile` coverage for `emulator/*.py`.
- Interpreter behavior: supports the requested instruction subset (MOV/MOVX/DPTR, INC DPTR, ANL/ORL/XRL/ADD immediates, CLR A, CJNE, limited branches, `LCALL`/`LJMP`/`RET`), logs unsupported opcodes explicitly, and provides a safe `allow_skip_unsupported` mode.

### Testing

- Ran `python3 scripts/firmware_execution_sandbox.py list-scenarios` which listed scenarios successfully.
- Ran `python3 scripts/firmware_execution_sandbox.py run-scenario packet_bridge_default --max-steps 100` which completed and produced outputs in `docs/emulator/` including per-run traces and summary CSVs.
- Executed `python3 scripts/run_analysis_smoke_test.py` which included the new sandbox smoke checks and wrote `docs/analysis_smoke_test_results.csv` with no failures.
- Verified syntax by running `python3 -m py_compile scripts/*.py emulator/*.py`, which succeeded without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef93ad866083308e003b0d519d6cd7)