### PR TITLE
Issue #74: extend 8051 sandbox opcode coverage for packet bridge tracing

### DIFF
--- a/docs/emulator/candidate_packet_records.csv
+++ b/docs/emulator/candidate_packet_records.csv
@@ -1,2 +1,2 @@
 run_id,scenario,function_addr,record_base,record_bytes,source_xdata_addrs,possible_role,confidence,evidence_level,notes
-packet_bridge_default_5602_20260427T165433Z,packet_bridge_default,0x5602,0x0000,1,0x0000,unknown_record,low,emulation_observed,Grouped contiguous observed XDATA writes only; format not decoded.
+packet_bridge_default_5602_20260427T171137Z,packet_bridge_default,0x5602,0x0000,1,0x0000,unknown_record,low,emulation_observed,Grouped contiguous observed XDATA writes only; format not decoded.

--- a/docs/emulator/function_trace_summary.csv
+++ b/docs/emulator/function_trace_summary.csv
@@ -1,4 +1,4 @@
 run_id,scenario,firmware_file,function_addr,steps,stop_reason,calls_seen,returns_seen,xdata_reads,xdata_writes,unsupported_ops,confidence,notes
-packet_bridge_default_55AD_20260427T165433Z,packet_bridge_default,90CYE03_19_DKS.PZU,0x55AD,4,unsupported_opcode 0x08 at 0x55CF,1,1,1,0,1,low,emulation_observed
-packet_bridge_default_5602_20260427T165433Z,packet_bridge_default,90CYE03_19_DKS.PZU,0x5602,4,unsupported_opcode 0x09 at 0x5607,1,1,0,1,1,low,emulation_observed
-packet_bridge_default_5A7F_20260427T165433Z,packet_bridge_default,90CYE03_19_DKS.PZU,0x5A7F,1,unsupported_opcode 0x25 at 0x5A7F,0,0,0,0,1,low,emulation_observed
+packet_bridge_default_55AD_20260427T171137Z,packet_bridge_default,90CYE03_19_DKS.PZU,0x55AD,5,unsupported_opcode 0xB8 at 0x55D0,1,1,1,0,1,low,emulation_observed
+packet_bridge_default_5602_20260427T171137Z,packet_bridge_default,90CYE03_19_DKS.PZU,0x5602,6,unsupported_opcode 0xB8 at 0x5609,1,1,0,1,1,low,emulation_observed
+packet_bridge_default_5A7F_20260427T171137Z,packet_bridge_default,90CYE03_19_DKS.PZU,0x5A7F,2,unsupported_opcode 0xF5 at 0x5A81,0,0,0,0,1,low,emulation_observed

--- a/docs/emulator/unsupported_opcode_report.csv
+++ b/docs/emulator/unsupported_opcode_report.csv
@@ -1,4 +1,4 @@
 opcode,pc,function_addr,count,first_seen_run,notes
-0x08,0x55CF,0x55AD,1,packet_bridge_default_55AD_20260427T165433Z,unsupported
-0x09,0x5607,0x5602,1,packet_bridge_default_5602_20260427T165433Z,unsupported
-0x25,0x5A7F,0x5A7F,1,packet_bridge_default_5A7F_20260427T165433Z,unsupported
+0xB8,0x55D0,0x55AD,1,packet_bridge_default_55AD_20260427T171137Z,unsupported
+0xB8,0x5609,0x5602,1,packet_bridge_default_5602_20260427T171137Z,unsupported
+0xF5,0x5A81,0x5A7F,1,packet_bridge_default_5A7F_20260427T171137Z,unsupported

--- a/docs/emulator/xdata_write_trace.csv
+++ b/docs/emulator/xdata_write_trace.csv
@@ -1,2 +1,2 @@
 run_id,scenario,firmware_file,function_addr,step,pc,xdata_addr,value,previous_value,watchpoint_hit,possible_role,notes
-packet_bridge_default_5602_20260427T165433Z,packet_bridge_default,90CYE03_19_DKS.PZU,0x5602,3,0x5606,0x0000,0x00,,False,unknown_record,emulation_observed
+packet_bridge_default_5602_20260427T171137Z,packet_bridge_default,90CYE03_19_DKS.PZU,0x5602,3,0x5606,0x0000,0x00,,False,unknown_record,emulation_observed

--- a/emulator/cpu8051_subset.py
+++ b/emulator/cpu8051_subset.py
@@ -138,6 +138,13 @@ class CPU8051Subset:
             self._log_instr("INC", "DPTR", pc, acc_before, dptr_before)
             return True, None
 
+        if 0x08 <= op <= 0x0F:  # INC Rn
+            n = op - 0x08
+            s.regs[n] = (s.regs[n] + 1) & 0xFF
+            s.pc += 1
+            self._log_instr("INC", f"R{n}", pc, acc_before, dptr_before)
+            return True, None
+
         if op in (0x54, 0x44, 0x64, 0x24):
             imm = self.fetch(pc + 1)
             if op == 0x54:
@@ -154,6 +161,14 @@ class CPU8051Subset:
                 opname = "ADD"
             s.pc += 2
             self._log_instr(opname, f"A,#0x{imm:02X}", pc, acc_before, dptr_before)
+            return True, None
+
+        if op == 0x25:  # ADD A,direct
+            direct = self.fetch(pc + 1)
+            value = s.xdata.get(direct, 0)
+            s.acc = (s.acc + value) & 0xFF
+            s.pc += 2
+            self._log_instr("ADD", f"A,0x{direct:02X}", pc, acc_before, dptr_before, notes="direct_read_model=xdata")
             return True, None
 
         if op == 0xE4:


### PR DESCRIPTION
### Motivation
- The emulator hit early unsupported opcodes when running the `packet_bridge_default` scenario, preventing deeper function traces for packet-bridge targets. 
- Improve the 8051-subset opcode coverage so targeted functions can advance further in the sandbox and produce richer XDATA/trace artifacts.

### Description
- Implemented `INC Rn` handling for opcodes `0x08..0x0F` in `emulator/cpu8051_subset.py` to model register increments. 
- Implemented `ADD A,direct` handling for opcode `0x25` using the sandbox direct-read model (reads from `s.xdata`) in `emulator/cpu8051_subset.py`.
- Re-ran the `packet_bridge_default` scenario and refreshed emulator outputs under `docs/emulator`, updating `function_trace_summary.csv`, `unsupported_opcode_report.csv`, `xdata_write_trace.csv`, and `candidate_packet_records.csv`.
- Committed the emulator changes and the regenerated scenario artifacts.

### Testing
- Ran `python3 scripts/firmware_execution_sandbox.py run-scenario packet_bridge_default` and it completed successfully producing updated emulator CSVs. 
- Ran the repository smoke test `python3 scripts/run_analysis_smoke_test.py` and it completed successfully with `Total commands: 63; failed: 0`. 
- Verified the updated artifacts `docs/emulator/function_trace_summary.csv`, `docs/emulator/unsupported_opcode_report.csv`, `docs/emulator/xdata_write_trace.csv`, and `docs/emulator/candidate_packet_records.csv` were produced by the scenario run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef97f3f1008330a79a1a702e6b9d93)